### PR TITLE
refactor: SocketBuf::fill

### DIFF
--- a/srcs/SocketBuf.hpp
+++ b/srcs/SocketBuf.hpp
@@ -128,9 +128,9 @@ class SocketBuf {
   int fill() {
     static const int flags = 0;
     int prev_size = recvbuf.size();
-    recvbuf.resize(recvbuf.size() + MAXLINE);
+    recvbuf.resize(prev_size + MAXLINE);
     ssize_t ret = ::recv(socket.get_fd(), \
-        &recvbuf[recvbuf.size() - MAXLINE], MAXLINE, flags);
+        &recvbuf[prev_size], MAXLINE, flags);
     if (ret < 0) {
       std::cerr << "recv() failed\n";
       recvbuf.resize(prev_size);
@@ -139,7 +139,7 @@ class SocketBuf {
     if (ret == 0) {
       socket.beClosed();
     }
-    recvbuf.resize(recvbuf.size() - MAXLINE + ret);
+    recvbuf.resize(prev_size + ret);
     return ret;
   }
 

--- a/srcs/SocketBuf.hpp
+++ b/srcs/SocketBuf.hpp
@@ -126,17 +126,19 @@ class SocketBuf {
 
   // Actually receive data from socket
   int fill() {
-    char buf[MAXLINE];
     static const int flags = 0;
-    ssize_t ret = ::recv(socket.get_fd(), buf, sizeof(buf) - 1, flags);
+    recvbuf.reserve(recvbuf.size() + MAXLINE);
+    recvbuf.resize(recvbuf.size() + MAXLINE);
+    ssize_t ret = ::recv(socket.get_fd(), \
+        &recvbuf[recvbuf.size() - MAXLINE], MAXLINE, flags);
     if (ret < 0) {
       std::cerr << "recv() failed\n";
       return -1;
     }
-    recvbuf.insert(recvbuf.end(), buf, buf + ret);
     if (ret == 0) {
       socket.beClosed();
     }
+    recvbuf.resize(recvbuf.size() - MAXLINE + ret);
     return ret;
   }
 

--- a/srcs/SocketBuf.hpp
+++ b/srcs/SocketBuf.hpp
@@ -127,12 +127,13 @@ class SocketBuf {
   // Actually receive data from socket
   int fill() {
     static const int flags = 0;
-    recvbuf.reserve(recvbuf.size() + MAXLINE);
+    int prev_size = recvbuf.size();
     recvbuf.resize(recvbuf.size() + MAXLINE);
     ssize_t ret = ::recv(socket.get_fd(), \
         &recvbuf[recvbuf.size() - MAXLINE], MAXLINE, flags);
     if (ret < 0) {
       std::cerr << "recv() failed\n";
+      recvbuf.resize(prev_size);
       return -1;
     }
     if (ret == 0) {


### PR DESCRIPTION
When receiving data from socket, directly assign to `recvbuf` without saving it in a temporary buffer.