### PR TITLE
:recycle: Refactor Server::accept

### DIFF
--- a/srcs/Connection.hpp
+++ b/srcs/Connection.hpp
@@ -23,8 +23,11 @@ class Connection {
   Status status;
  public:
   // Constructor/Destructor
-  Connection(): client_socket(NULL), header(), status(REQ_START_LINE) {}
-  Connection(std::shared_ptr<SocketBuf> client_socket) : client_socket(client_socket), header(), status(REQ_START_LINE) {}
+  Connection(); // Do not implement this
+  explicit Connection(int listen_fd) : 
+    client_socket(new SocketBuf(listen_fd)),
+    header(),
+    status(REQ_START_LINE) {}
   ~Connection() {}
   Connection(const Connection &other) { *this = other; }
   Connection &operator=(const Connection &other) {

--- a/srcs/Socket.hpp
+++ b/srcs/Socket.hpp
@@ -28,13 +28,16 @@ class Socket {
   Socket() : server_addr(), closed(false) {
     if ( (fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0) {
       std::cerr << "socket() failed\n";
+      throw std::runtime_error("socket() failed");
     }
   }
-  Socket(int fd): fd(fd), server_addr(), closed(false) {}
-  ~Socket() {
-    if (fd < 0) {
-      return;
+  explicit Socket(int listen_fd): server_addr(), closed(false) {
+    if ( (fd = accept(listen_fd, NULL, NULL)) < 0) {
+      std::cerr << "accept() failed\n";
+      throw std::runtime_error("accept() failed");
     }
+  }
+  ~Socket() {
     if (::close(fd) < 0) {
       std::cerr << "close() failed\n";
     }

--- a/srcs/SocketBuf.hpp
+++ b/srcs/SocketBuf.hpp
@@ -25,8 +25,12 @@ class SocketBuf {
 
  public:
   // Constructor/Destructor
-  SocketBuf(): socket(-1) {}
-  SocketBuf(int fd): socket(fd) {}
+  SocketBuf(); // Do not implement this
+  explicit SocketBuf(int listen_fd): socket(listen_fd) {
+    if (socket.set_nonblock() < 0) {
+      throw std::runtime_error("socket.set_nonblock() failed");
+    }
+  }
   ~SocketBuf() {}
 
   // Accessors

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -6,14 +6,12 @@
 
 int main(int argc, char *argv[]) {
   (void)argc, (void)argv;
-  // If initialize server socket failed, exit.
-  Server server;
+  // We do not handle exceptions in constructor of Server.
+  // Just end this program in that case.
+  Server server(PORT, BACKLOG);
 
   if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
     std::cerr << "signal() failed\n";
-    return ERROR;
-  }
-  if (server.init(PORT, BACKLOG) < 0) {
     return ERROR;
   }
   while (1) {


### PR DESCRIPTION
acceptが成功して`client_fd`を取得した後に、`new SocketBuf`が失敗した場合に、closeができない問題を解決するために幾つかのリファクタを行いました。


```
    struct sockaddr_in addr;
    socklen_t addrlen = sizeof(addr);
    int client_fd = ::accept(sock.get_fd(), (struct sockaddr *)&addr, &addrlen);
    if (client_fd < 0) {
      std::cerr << "accept() failed\n";
      // TODO: handle error
      return;
    }

    // もしこのoperator newでallocationが失敗した場合に、client_fdがcloseできないという問題があった
    std::shared_ptr<SocketBuf> client_socket = \
        std::shared_ptr<SocketBuf>(new SocketBuf(client_fd));
```