### PR TITLE
♻️ 作成した関数では例外を使用しないように修正

### DIFF
--- a/srcs/Connection.hpp
+++ b/srcs/Connection.hpp
@@ -1,6 +1,7 @@
 #ifndef CONNECTION_HPP
 #define CONNECTION_HPP
 
+#include "webserv.hpp"
 #include "GetHandler.hpp"
 #include "Header.hpp"
 #include "SocketBuf.hpp"
@@ -46,7 +47,7 @@ class Connection {
     } else if (shouldSend()) {
       if (client_socket->flush() < 0) {
         if (client_socket->isClosed()) {
-          std::cerr << "client_socket->closed\n";
+          Log::info("client_socket->closed");
           status = DONE;
         }
       }
@@ -121,7 +122,7 @@ class Connection {
 
     if (client_socket->readline(line) < 0) {
       if (client_socket->isClosed()) {
-        std::cerr << "client_socket->closed\n";
+        Log::info("client_socket->closed");
         status = DONE;
         return 1;
       }
@@ -129,7 +130,7 @@ class Connection {
     }
     std::vector<std::string> keywords = split(line, ' ');
     if (keywords.size() != 3) {
-      std::cerr << "Invalid start line: " << line << std::endl;
+      Log::cinfo() << "Invalid start line: " << line << std::endl;
       client_socket->send("HTTP/1.1 400 Bad Request\r\n", 26);
       status = RESPONSE;
       return 1;
@@ -158,7 +159,7 @@ class Connection {
     if (header.method == "GET") {
       GetHandler::handle(client_socket, header);
     } else {
-      std::cerr << "Unsupported method: " << header.method << std::endl;
+      Log::cinfo() << "Unsupported method: " << header.method << std::endl;
       client_socket->send("HTTP/1.1 405 Method Not Allowed\r\n", 34);
     }
     status = RESPONSE;

--- a/srcs/Connection.hpp
+++ b/srcs/Connection.hpp
@@ -1,10 +1,10 @@
 #ifndef CONNECTION_HPP
 #define CONNECTION_HPP
 
-#include "webserv.hpp"
 #include "GetHandler.hpp"
 #include "Header.hpp"
 #include "SocketBuf.hpp"
+#include "webserv.hpp"
 
 class Connection {
  private:

--- a/srcs/Connection.hpp
+++ b/srcs/Connection.hpp
@@ -21,13 +21,14 @@ class Connection {
   std::shared_ptr<SocketBuf> client_socket;
   Header header;
   Status status;
+
  public:
   // Constructor/Destructor
-  Connection(); // Do not implement this
-  explicit Connection(int listen_fd) : 
-    client_socket(new SocketBuf(listen_fd)),
-    header(),
-    status(REQ_START_LINE) {}
+  Connection();  // Do not implement this
+  explicit Connection(int listen_fd)
+      : client_socket(new SocketBuf(listen_fd)),
+        header(),
+        status(REQ_START_LINE) {}
   ~Connection() {}
   Connection(const Connection &other) { *this = other; }
   Connection &operator=(const Connection &other) {
@@ -96,7 +97,7 @@ class Connection {
 
   bool shouldSend() { return status == HANDLE || status == RESPONSE; }
 
-private:
+ private:
   // TODO: refactor? fix?
   static std::vector<std::string> split(std::string str, char delim) {
     std::vector<std::string> ret;

--- a/srcs/Connection.hpp
+++ b/srcs/Connection.hpp
@@ -24,27 +24,22 @@ class Connection {
 
  public:
   // Constructor/Destructor
-  Connection();  // Do not implement this
+  Connection() throw();  // Do not implement this
   explicit Connection(int listen_fd)
       : client_socket(new SocketBuf(listen_fd)),
         header(),
         status(REQ_START_LINE) {}
-  ~Connection() {}
-  Connection(const Connection &other) { *this = other; }
-  Connection &operator=(const Connection &other) {
-    if (this != &other) {
-      client_socket = other.client_socket;
-      header = other.header;
-      status = other.status;
-    }
-    return *this;
-  }
+  ~Connection() throw() {}
+  Connection(const Connection &other) throw();  // Do not implement this
+  Connection &operator=(
+      const Connection &other) throw();  // Do not implement this
 
   // Accessors
-  int get_fd() { return client_socket->get_fd(); }
-  bool is_done() { return status == DONE; }
+  int get_fd() const throw() { return client_socket->get_fd(); }
+  bool is_done() const throw() { return status == DONE; }
 
   // Member functions
+  // TODO: make this noexcept
   int resume() {
     if (shouldRecv()) {
       client_socket->fill();
@@ -90,15 +85,18 @@ class Connection {
     return 0;
   }
 
-  bool shouldRecv() {
+  bool shouldRecv() const throw() {
     return status == REQ_START_LINE || status == REQ_HEADER_FIELDS ||
            status == REQ_BODY;
   }
 
-  bool shouldSend() { return status == HANDLE || status == RESPONSE; }
+  bool shouldSend() const throw() {
+    return status == HANDLE || status == RESPONSE;
+  }
 
  private:
   // TODO: refactor? fix?
+  // TODO: make this noexcept
   static std::vector<std::string> split(std::string str, char delim) {
     std::vector<std::string> ret;
     int idx = 0;

--- a/srcs/GetHandler.hpp
+++ b/srcs/GetHandler.hpp
@@ -22,18 +22,18 @@ class GetHandler {
   ~GetHandler() throw();                             // Do not implement this
  public:
   // Member functions
-  // TODO: Make this noexcept
   static void handle(std::shared_ptr<SocketBuf> client_socket,
                      const Header& header) throw() {
     // TODO: Write response headers
     std::stringstream ss;
-    ssize_t content_length = get_content_length(header.path);
-    if (content_length < 0) {
+    ssize_t content_length;
+
+    if ((content_length = get_content_length(header.path)) < 0) {
+      Log::error("get_content_length() failed");
       ss << "HTTP/1.1 404 Resource Not Found\r\n";
       // TODO send some error message
       ss << "\r\n";
       client_socket->send(ss.str().c_str(), ss.str().size());
-      Log::error("get_content_length() failed");
       return;
     }
     ss << "HTTP/1.1 200 OK\r\n";
@@ -43,13 +43,13 @@ class GetHandler {
     ss << "\r\n";
     client_socket->send(ss.str().c_str(), ss.str().size());
     if (client_socket->send_file(header.path) < 0) {
+      Log::error("send_file() failed");
       client_socket->clear_sendbuf();
       ss.str("");
       ss << "HTTP/1.1 500 Internal Server Error\r\n";
       // TODO send some error message
       ss << "\r\n";
       client_socket->send(ss.str().c_str(), ss.str().size());
-      Log::error("send_file() failed");
       return;
     }
   }

--- a/srcs/GetHandler.hpp
+++ b/srcs/GetHandler.hpp
@@ -16,10 +16,10 @@
 class GetHandler {
  private:
   // Constructor/Destructor/Assignment Operator
-  GetHandler();                              // Do not implement this
-  GetHandler(const GetHandler&);             // Do not implement this
-  GetHandler& operator=(const GetHandler&);  // Do not implement this
-  ~GetHandler();                             // Do not implement this
+  GetHandler() throw();                              // Do not implement this
+  GetHandler(const GetHandler&) throw();             // Do not implement this
+  GetHandler& operator=(const GetHandler&) throw();  // Do not implement this
+  ~GetHandler() throw();                             // Do not implement this
  public:
   // Member functions
   // TODO: Make this noexcept

--- a/srcs/GetHandler.hpp
+++ b/srcs/GetHandler.hpp
@@ -18,7 +18,8 @@ class GetHandler {
   // Member data
   // Constructor/Destructor
   // Member functions
-  static void handle(std::shared_ptr<SocketBuf> client_socket, const Header& header) {
+  static void handle(std::shared_ptr<SocketBuf> client_socket,
+                     const Header& header) {
     // TODO: Write response headers
     std::stringstream ss;
     ssize_t content_length = get_content_length(header.path);

--- a/srcs/GetHandler.hpp
+++ b/srcs/GetHandler.hpp
@@ -33,7 +33,7 @@ class GetHandler {
       // TODO send some error message
       ss << "\r\n";
       client_socket->send(ss.str().c_str(), ss.str().size());
-      std::cerr << "get_content_length() failed\n";
+      Log::error("get_content_length() failed");
       return;
     }
     ss << "HTTP/1.1 200 OK\r\n";
@@ -49,7 +49,7 @@ class GetHandler {
       // TODO send some error message
       ss << "\r\n";
       client_socket->send(ss.str().c_str(), ss.str().size());
-      std::cerr << "send_file() failed\n";
+      Log::error("send_file() failed");
       return;
     }
   }

--- a/srcs/GetHandler.hpp
+++ b/srcs/GetHandler.hpp
@@ -14,12 +14,17 @@
 #include "webserv.hpp"
 
 class GetHandler {
+ private:
+  // Constructor/Destructor/Assignment Operator
+  GetHandler();                              // Do not implement this
+  GetHandler(const GetHandler&);             // Do not implement this
+  GetHandler& operator=(const GetHandler&);  // Do not implement this
+  ~GetHandler();                             // Do not implement this
  public:
-  // Member data
-  // Constructor/Destructor
   // Member functions
+  // TODO: Make this noexcept
   static void handle(std::shared_ptr<SocketBuf> client_socket,
-                     const Header& header) {
+                     const Header& header) throw() {
     // TODO: Write response headers
     std::stringstream ss;
     ssize_t content_length = get_content_length(header.path);
@@ -50,7 +55,7 @@ class GetHandler {
   }
 
  private:
-  static ssize_t get_content_length(const std::string& filepath) {
+  static ssize_t get_content_length(const std::string& filepath) throw() {
     struct stat st;
     if (stat(filepath.c_str(), &st) < 0) {
       std::cerr << "stat() failed\n";

--- a/srcs/Header.hpp
+++ b/srcs/Header.hpp
@@ -6,14 +6,17 @@
 #include "webserv.hpp"
 
 class Header {
+ private:
+  Header(const Header &src) throw();             // Do not implement
+  Header &operator=(const Header &rhs) throw();  // Do not implement
  public:
   // Member data
   std::string method;
   std::string path;
   std::string version;
   // Constructor/Destructor
-  Header() {}
-  ~Header() {}
+  Header() throw() {}
+  ~Header() throw() {}
   // Member functions
 };
 

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -3,9 +3,7 @@
 static Log::Level log_level_ = Log::Debug;
 static std::ofstream devnull_;
 
-void Log::setLevel(Level level) throw() {
-  log_level_ = level;
-}
+void Log::setLevel(Level level) throw() { log_level_ = level; }
 
 // debug, info, warn, error, fatal are for use with printf-style formatting
 void Log::debug(const char* format, ...) throw() {
@@ -58,7 +56,7 @@ void Log::fatal(const char* format, ...) throw() {
     va_list args;
     va_start(args, format);
     vsnprintf(buf, MAX_LOG_LENGTH, format, args);
-    std::cerr << "[FATAL] "<< buf << std::endl;
+    std::cerr << "[FATAL] " << buf << std::endl;
     va_end(args);
   }
 }

--- a/srcs/Log.hpp
+++ b/srcs/Log.hpp
@@ -1,26 +1,20 @@
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 #define MAX_LOG_LENGTH 1024
 
 namespace Log {
-  enum Level {
-    Debug,
-    Info,
-    Warn,
-    Error,
-    Fatal
-  };
-  void setLevel(Level level) throw();
-  void debug(const char* format, ...) throw();
-  void info(const char* format, ...) throw();
-  void warn(const char* format, ...) throw();
-  void error(const char* format, ...) throw();
-  void fatal(const char* format, ...) throw();
+enum Level { Debug, Info, Warn, Error, Fatal };
+void setLevel(Level level) throw();
+void debug(const char* format, ...) throw();
+void info(const char* format, ...) throw();
+void warn(const char* format, ...) throw();
+void error(const char* format, ...) throw();
+void fatal(const char* format, ...) throw();
 
-  std::ostream& cdebug() throw();
-  std::ostream& cinfo() throw();
-  std::ostream& cwarn() throw();
-  std::ostream& cerror() throw();
-  std::ostream& cfatal() throw();
-}
+std::ostream& cdebug() throw();
+std::ostream& cinfo() throw();
+std::ostream& cwarn() throw();
+std::ostream& cerror() throw();
+std::ostream& cfatal() throw();
+}  // namespace Log

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -122,7 +122,7 @@ class Server {
            (conn->shouldSend() && FD_ISSET(conn->get_fd(), &ready_wfds));
   }
 
-  // This can be const, but it returns pointer, so logically it is not const.
+  // Logically it is not const because it returns a non-const pointer.
   std::shared_ptr<Connection> get_ready_connection() throw() {
     // TODO: equally distribute the processing time to each connection
     for (ConnIterator it = connections.begin(); it != connections.end(); ++it) {

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -1,16 +1,17 @@
 #ifndef SERVER_HPP
 #define SERVER_HPP
 
+#include <algorithm>  // std::find
+
 #include "Connection.hpp"
 #include "GetHandler.hpp"
 #include "Header.hpp"
 #include "SocketBuf.hpp"
 #include "webserv.hpp"
-#include <algorithm> // std::find
 
 class Server {
  private:
-  typedef std::vector< std::shared_ptr<Connection> > ConnVector;
+  typedef std::vector<std::shared_ptr<Connection> > ConnVector;
   typedef ConnVector::iterator ConnIterator;
   fd_set readfds, writefds;
   fd_set ready_rfds, ready_wfds;
@@ -22,7 +23,7 @@ class Server {
   ConnVector connections;
 
   // Constructor/Destructor
-  Server(); // Do not implement this
+  Server();  // Do not implement this
   Server(int port, int backlog) : sock(), connections() {
     FD_ZERO(&readfds);
     FD_ZERO(&writefds);
@@ -51,7 +52,8 @@ class Server {
     FD_CLR(connection->get_fd(), &writefds);
     if (connection->get_fd() == maxfd) {
       maxfd = sock.get_fd();
-      for (ConnIterator it = connections.begin(); it != connections.end(); it++) {
+      for (ConnIterator it = connections.begin(); it != connections.end();
+           it++) {
         maxfd = std::max(maxfd, (*it)->get_fd());
       }
     }
@@ -88,7 +90,7 @@ class Server {
     }
     return false;
   }
-  
+
   void update_fdset(std::shared_ptr<Connection> conn) {
     if (conn->shouldRecv()) {
       FD_SET(conn->get_fd(), &readfds);
@@ -138,7 +140,7 @@ class Server {
     std::shared_ptr<Connection> conn;
     if (canServerAccept(ready_rfds)) {
       accept();
-    } else if (conn = get_ready_connection()) {
+    } else if ((conn = get_ready_connection())) {
       // conn->resume() may throw an exception from STL containers
       try {
         conn->resume();

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -106,11 +106,11 @@ class Server {
     tv.tv_usec = 0;
     int result = ::select(maxfd + 1, &ready_rfds, &ready_wfds, NULL, &tv);
     if (result < 0) {
-      std::cerr << "select error" << std::endl;
+      Log::error("select error");
       return -1;
     }
     if (result == 0) {
-      std::cerr << "select timeout" << std::endl;
+      Log::info("select timeout");
       remove_all_connections();
       return -1;
     }
@@ -146,12 +146,12 @@ class Server {
       try {
         conn->resume();
       } catch (std::exception &e) {
-        std::cerr << "connection aborted: " << e.what() << std::endl;
+        Log::cerror() << "connection aborted: " << e.what() << std::endl;
         remove_connection(conn);
         return;
       }
       if (conn->is_done()) {
-        std::cout << "connection done" << std::endl;
+        Log::info("connection done");
         remove_connection(conn);
       } else {
         update_fdset(conn);

--- a/srcs/Socket.hpp
+++ b/srcs/Socket.hpp
@@ -26,13 +26,13 @@ class Socket {
  public:
   // Constructor/Destructor
   Socket() : server_addr(), closed(false) {
-    if ( (fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0) {
+    if ((fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0) {
       std::cerr << "socket() failed\n";
       throw std::runtime_error("socket() failed");
     }
   }
-  explicit Socket(int listen_fd): server_addr(), closed(false) {
-    if ( (fd = accept(listen_fd, NULL, NULL)) < 0) {
+  explicit Socket(int listen_fd) : server_addr(), closed(false) {
+    if ((fd = accept(listen_fd, NULL, NULL)) < 0) {
       std::cerr << "accept() failed\n";
       throw std::runtime_error("accept() failed");
     }
@@ -62,7 +62,7 @@ class Socket {
     server_addr.sin_family = AF_INET;
     server_addr.sin_port = htons(port);
     server_addr.sin_addr.s_addr = INADDR_ANY;
-    if (::bind(fd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+    if (::bind(fd, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
       std::cerr << "bind() failed\n";
       return -1;
     }

--- a/srcs/Socket.hpp
+++ b/srcs/Socket.hpp
@@ -28,19 +28,19 @@ class Socket {
   // Constructor/Destructor
   Socket() : server_addr(), closed(false) {
     if ((fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0) {
-      std::cerr << "socket() failed\n";
+      Log::fatal("socket() failed");
       throw std::runtime_error("socket() failed");
     }
   }
   explicit Socket(int listen_fd) : server_addr(), closed(false) {
     if ((fd = accept(listen_fd, NULL, NULL)) < 0) {
-      std::cerr << "accept() failed\n";
+      Log::error("accept() failed");
       throw std::runtime_error("accept() failed");
     }
   }
   ~Socket() throw() {
     if (::close(fd) < 0) {
-      std::cerr << "close() failed\n";
+      Log::error("close() failed");
     }
   }
 
@@ -53,7 +53,7 @@ class Socket {
   int reuseaddr() throw() {
     int optval = 1;
     if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) < 0) {
-      std::cerr << "setsockopt() failed\n";
+      Log::error("setsockopt() failed");
       return -1;
     }
     return 0;
@@ -64,7 +64,7 @@ class Socket {
     server_addr.sin_port = htons(port);
     server_addr.sin_addr.s_addr = INADDR_ANY;
     if (::bind(fd, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
-      std::cerr << "bind() failed\n";
+      Log::error("bind() failed");
       return -1;
     }
     return 0;
@@ -72,7 +72,7 @@ class Socket {
 
   int listen(int backlog) throw() {
     if (::listen(fd, backlog) < 0) {
-      std::cerr << "listen() failed\n";
+      Log::error("listen() failed");
       return -1;
     }
     return 0;
@@ -81,11 +81,11 @@ class Socket {
   int set_nonblock() throw() {
     int flags = fcntl(fd, F_GETFL, 0);
     if (flags < 0) {
-      std::cerr << "fcntl() failed\n";
+      Log::error("fcntl() failed");
       return -1;
     }
     if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
-      std::cerr << "fcntl() failed\n";
+      Log::error("fcntl() failed");
       return -1;
     }
     return 0;

--- a/srcs/Socket.hpp
+++ b/srcs/Socket.hpp
@@ -21,7 +21,8 @@ class Socket {
   struct sockaddr_in server_addr;
   bool closed;
 
-  Socket(const Socket& other);
+  Socket(const Socket& other) throw();             // Do not implement this
+  Socket& operator=(const Socket& other) throw();  // Do not implement this
 
  public:
   // Constructor/Destructor
@@ -37,19 +38,19 @@ class Socket {
       throw std::runtime_error("accept() failed");
     }
   }
-  ~Socket() {
+  ~Socket() throw() {
     if (::close(fd) < 0) {
       std::cerr << "close() failed\n";
     }
   }
 
   // Accessors
-  int get_fd() const { return fd; }
-  bool isClosed() const { return closed; }
-  void beClosed() { closed = true; }
+  int get_fd() const throw() { return fd; }
+  bool isClosed() const throw() { return closed; }
+  void beClosed() throw() { closed = true; }
 
   // Member functions
-  int reuseaddr() {
+  int reuseaddr() throw() {
     int optval = 1;
     if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) < 0) {
       std::cerr << "setsockopt() failed\n";
@@ -58,7 +59,7 @@ class Socket {
     return 0;
   }
 
-  int bind(int port) {
+  int bind(int port) throw() {
     server_addr.sin_family = AF_INET;
     server_addr.sin_port = htons(port);
     server_addr.sin_addr.s_addr = INADDR_ANY;
@@ -69,7 +70,7 @@ class Socket {
     return 0;
   }
 
-  int listen(int backlog) {
+  int listen(int backlog) throw() {
     if (::listen(fd, backlog) < 0) {
       std::cerr << "listen() failed\n";
       return -1;
@@ -77,7 +78,7 @@ class Socket {
     return 0;
   }
 
-  int set_nonblock() {
+  int set_nonblock() throw() {
     int flags = fcntl(fd, F_GETFL, 0);
     if (flags < 0) {
       std::cerr << "fcntl() failed\n";

--- a/srcs/SocketBuf.hpp
+++ b/srcs/SocketBuf.hpp
@@ -23,12 +23,14 @@ class SocketBuf {
   bool stl_error;
 
   SocketBuf() throw();  // Do not implement this
-  SocketBuf& operator=(const SocketBuf& other) throw();  // Do not implement this
+  SocketBuf& operator=(
+      const SocketBuf& other) throw();  // Do not implement this
   SocketBuf(SocketBuf& other) throw();  // Do not implement this
 
  public:
   // Constructor/Destructor
-  explicit SocketBuf(int listen_fd) : socket(listen_fd), recvbuf(), sendbuf(), stl_error(false) {
+  explicit SocketBuf(int listen_fd)
+      : socket(listen_fd), recvbuf(), sendbuf(), stl_error(false) {
     if (socket.set_nonblock() < 0) {
       throw std::runtime_error("socket.set_nonblock() failed");
     }
@@ -94,7 +96,8 @@ class SocketBuf {
       if (prev == '\r' && c == '\n') {
         // try/catch
         try {
-          line.assign(recvbuf.begin(), recvbuf.begin() + i - 1);  // Remove "\r\n"
+          line.assign(recvbuf.begin(),
+                      recvbuf.begin() + i - 1);  // Remove "\r\n"
         } catch (const std::exception& e) {
           Log::fatal("line.assign() failed");
           stl_error = true;
@@ -152,13 +155,13 @@ class SocketBuf {
     ssize_t ret = ::recv(socket.get_fd(), &recvbuf[prev_size], MAXLINE, flags);
     if (ret < 0) {
       Log::error("recv() failed");
-      recvbuf.resize(prev_size); // won't throw because it will shrink
+      recvbuf.resize(prev_size);  // won't throw because it will shrink
       return -1;
     }
     if (ret == 0) {
       socket.beClosed();
     }
-    recvbuf.resize(prev_size + ret); // won't throw because it will shrink
+    recvbuf.resize(prev_size + ret);  // won't throw because it will shrink
     return ret;
   }
 

--- a/srcs/SocketBuf.hpp
+++ b/srcs/SocketBuf.hpp
@@ -54,7 +54,7 @@ class SocketBuf {
     std::ifstream ifs(filepath.c_str(), std::ios::binary);
 
     if (!ifs.is_open()) {
-      std::cerr << "file open failed\n";
+      Log::error("file open failed");
       return -1;
     }
     // try/catch
@@ -99,8 +99,7 @@ class SocketBuf {
     ssize_t ret = ::send(socket.get_fd(), &sendbuf[0],
                          std::min(10, (int)sendbuf.size()), 0);
     if (ret < 0) {
-      perror("send");
-      std::cerr << "errno: " << errno << "\n";
+      Log::cerror() << "send() failed, errno: " << errno << "\n";
       // TODO: handle EINTR
       // ETIMEDOUT, EPIPE in any case means the connection is closed
       socket.beClosed();
@@ -126,7 +125,7 @@ class SocketBuf {
     recvbuf.resize(prev_size + MAXLINE);
     ssize_t ret = ::recv(socket.get_fd(), &recvbuf[prev_size], MAXLINE, flags);
     if (ret < 0) {
-      std::cerr << "recv() failed\n";
+      Log::error("recv() failed");
       // won't throw because it will shrink
       recvbuf.resize(prev_size);
       return -1;

--- a/srcs/SocketBuf.hpp
+++ b/srcs/SocketBuf.hpp
@@ -11,8 +11,8 @@
 #define MAXLINE 1024
 #include <fcntl.h>
 
-#include "webserv.hpp"
 #include "Socket.hpp"
+#include "webserv.hpp"
 
 class SocketBuf {
   // Member data
@@ -25,8 +25,8 @@ class SocketBuf {
 
  public:
   // Constructor/Destructor
-  SocketBuf(); // Do not implement this
-  explicit SocketBuf(int listen_fd): socket(listen_fd) {
+  SocketBuf();  // Do not implement this
+  explicit SocketBuf(int listen_fd) : socket(listen_fd) {
     if (socket.set_nonblock() < 0) {
       throw std::runtime_error("socket.set_nonblock() failed");
     }
@@ -62,7 +62,7 @@ class SocketBuf {
 
   // Read line from buffer, if found, remove it from buffer and return 0
   // Otherwise, return -1
-  int readline(std::string &line) {
+  int readline(std::string& line) {
     char prev = '\0', c;
 
     for (size_t i = 0; i < recvbuf.size(); i++) {
@@ -82,14 +82,15 @@ class SocketBuf {
     if (sendbuf.empty()) {
       return 0;
     }
-    //ssize_t ret = ::send(fd, &sendbuf[0], sendbuf.size(), SO_NOSIGPIPE);
-    ssize_t ret = ::send(socket.get_fd(), &sendbuf[0], std::min(10, (int)sendbuf.size()), 0);
+    // ssize_t ret = ::send(fd, &sendbuf[0], sendbuf.size(), SO_NOSIGPIPE);
+    ssize_t ret = ::send(socket.get_fd(), &sendbuf[0],
+                         std::min(10, (int)sendbuf.size()), 0);
     if (ret < 0) {
       perror("send");
       std::cerr << "errno: " << errno << "\n";
       // TODO: handle EINTR
       // ETIMEDOUT, EPIPE in any case means the connection is closed
-	  socket.beClosed();
+      socket.beClosed();
       return -1;
     }
     sendbuf.erase(sendbuf.begin(), sendbuf.begin() + ret);
@@ -106,8 +107,7 @@ class SocketBuf {
     static const int flags = 0;
     int prev_size = recvbuf.size();
     recvbuf.resize(prev_size + MAXLINE);
-    ssize_t ret = ::recv(socket.get_fd(), \
-        &recvbuf[prev_size], MAXLINE, flags);
+    ssize_t ret = ::recv(socket.get_fd(), &recvbuf[prev_size], MAXLINE, flags);
     if (ret < 0) {
       std::cerr << "recv() failed\n";
       recvbuf.resize(prev_size);
@@ -120,14 +120,9 @@ class SocketBuf {
     return ret;
   }
 
-  void clear_sendbuf() {
-    sendbuf.clear();
-  }
+  void clear_sendbuf() { sendbuf.clear(); }
 
-  int set_nonblock() {
-    return socket.set_nonblock();
-  }
+  int set_nonblock() { return socket.set_nonblock(); }
 };
 
 #endif
-

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -1,6 +1,7 @@
 #include <signal.h>
-#include "webserv.hpp"
+
 #include "Server.hpp"
+#include "webserv.hpp"
 #define PORT 8181
 #define BACKLOG 5
 #define ERROR 1

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -1,6 +1,6 @@
-#include "Server.hpp"
 #include <signal.h>
 #include "Log.hpp"
+#include "Server.hpp"
 #define PORT 8181
 #define BACKLOG 5
 #define ERROR 1

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -1,5 +1,5 @@
 #include <signal.h>
-#include "Log.hpp"
+#include "webserv.hpp"
 #include "Server.hpp"
 #define PORT 8181
 #define BACKLOG 5
@@ -12,15 +12,16 @@ int main(int argc, char *argv[]) {
   // Just end this program in that case.
   Server server(PORT, BACKLOG);
 
+  Log::setLevel(Log::Debug);
   if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
-    std::cerr << "signal() failed\n";
+    Log::fatal("signal() failed");
     return ERROR;
   }
   while (1) {
     try {
       server.process(7);
     } catch (std::exception &e) {
-      std::cerr << e.what() << std::endl;
+      Log::cerror() << "Exception: " << e.what() << std::endl;
     }
   }
   return 0;

--- a/srcs/webserv.hpp
+++ b/srcs/webserv.hpp
@@ -7,4 +7,6 @@
 #include <iostream>
 #include <memory>  // std::shared_ptr for now, but should be removed before submission
 
+#include "Log.hpp"
+
 #endif

--- a/srcs/webserv.hpp
+++ b/srcs/webserv.hpp
@@ -3,8 +3,8 @@
 
 #define SERVER_NAME "webserv/0.0.1"
 #include <stdlib.h>  // exit for now, but should be removed before submission
-#include <memory> // std::shared_ptr for now, but should be removed before submission
 
 #include <iostream>
+#include <memory>  // std::shared_ptr for now, but should be removed before submission
 
 #endif


### PR DESCRIPTION
Constructor（nothrowなものにはthrow()を付加しておく）にのみ例外を許可する
例外を投げる可能性がある関数（STL、operator new、nothrowでないConstructor）はその場でtry/catchしてハンドリングする

という方針で、throwableな関数を作らない方針にリファクタしてみたいと思います。

どの関数がthrowするかもしれないか？とかを考えるのがやっぱり大変だと思うので、どの関数も例外を投げない、という方針にしてみたいなと・・・！