### PR TITLE
SocketBufに使用されるbufferをvectorからstringstreamに変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.d
 out
 webserv
+unit
+!tests/unit

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,18 @@
-CXXFLAGS  = -std=c++98 -Wall -Wextra -Werror -pedantic -MMD -MP
+INCLUDES  = $(wildcard srcs/*.hpp)
+CXXFLAGS  = -std=c++98 -Wall -Wextra -Werror -pedantic -MMD -MP -I include -I srcs
 SRCS      = $(wildcard srcs/*.cpp)
 OBJS	  = $(SRCS:.cpp=.o)
 DEPS	  = $(SRCS:.cpp=.d)
-INCLUDES  = $(wildcard srcs/*.hpp)
 NAME      = webserv
+UNITTEST  = unit
 
 all: $(NAME)
 
 clean:
-	rm -f $(OBJS) $(DEPS)
+	rm -f $(OBJS) $(DEPS) $(UNIT_OBJS) $(UNIT_DEPS)
 
 fclean: clean 
-	rm -f $(NAME)
+	rm -f $(NAME) $(UNITTEST)
 
 re: fclean all
 
@@ -19,6 +20,9 @@ re: fclean all
 # so we need to use c++11 on Linux
 linux: CXXFLAGS = -std=c++11 -Wall -Wextra -pedantic -MMD -MP
 linux: re
+
+%.o: %.cpp %.d
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 debug: CXXFLAGS = -std=c++98 -Wall -Wextra -pedantic -MMD -MP -fsanitize=address -fsanitize=undefined -D DEBUG
 debug: re
@@ -29,6 +33,13 @@ $(NAME): $(OBJS)
 
 test: $(NAME)
 	./tests/test.sh
+
+UNIT_SRCS = $(wildcard tests/unit/*.cpp)
+UNIT_OBJS = $(UNIT_SRCS:.cpp=.o)
+UNIT_DEPS = $(UNIT_SRCS:.cpp=.d)
+unit: $(OBJS) $(UNIT_OBJS)
+	$(CXX) -I srcs -I include $(UNIT_OBJS) $(filter-out srcs/main.o, $(OBJS)) -o $(UNITTEST)
+	./$(UNITTEST)
 
 format:
 	clang-format -style=google $(SRCS) $(INCLUDES) -i

--- a/playground/getline.cpp
+++ b/playground/getline.cpp
@@ -1,0 +1,34 @@
+#include <sstream>
+#include <iostream>
+#include <string>
+
+int main() {
+  std::stringstream ss;
+  //ss << "hoge\nfuga";
+  ss << "a" ;
+  std::string line;
+  while (std::getline(ss, line)) {
+    if (ss.eof()) {
+      std::cout << "EOF" << std::endl;
+      ss.seekg(-line.size(), std::ios::cur);
+      break;
+    }
+    std::cout << line << std::endl;
+    std::cout << ss.eof() << std::endl;
+  }
+  std::cout << "----------------" << std::endl;
+  std::cout << "ss.fail() = " << ss.fail() << std::endl;
+  std::cout << "ss.bad() = " << ss.bad() << std::endl;
+  std::cout << "ss.eof() = " << ss.eof() << std::endl;
+  ss << "fuga\n";
+  while (std::getline(ss, line)) {
+    if (ss.eof()) {
+      std::cout << "EOF" << std::endl;
+      ss.seekg(-line.size(), std::ios::cur);
+      break;
+    }
+    std::cout << line << std::endl;
+    std::cout << ss.eof() << std::endl;
+  }
+  return 0;
+}

--- a/playground/ss_avail.cpp
+++ b/playground/ss_avail.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <sstream>
+#include <string>
+
+// ss.in_avail() is not reliable
+// should use `ss.str().size() - ss.tellg()` instead
+int main() {
+    std::stringstream ss;
+    std::string w;
+    ss << "abc def   ghi";
+    std::cout << "avail: " << ss.rdbuf()->in_avail() << std::endl; // Before tellg(), in_avail() returns 1
+    std::cout << "size: " << ss.str().size() << std::endl;
+    std::cout << "avail: " << ss.rdbuf()->in_avail() << std::endl; // Before tellg(), in_avail() returns 1
+    std::cout << "tellg: " << ss.tellg() << std::endl;
+    std::cout << "avail: " << ss.rdbuf()->in_avail() << std::endl; // After tellg(), in_avail() returns 13
+    std::cout << "tellp: " << ss.tellp() << std::endl;
+
+    std::cout << "size: " << ss.str().size() << ", tellg: " << ss.tellg() << ", avail: " << ss.rdbuf()->in_avail() << std::endl;
+    std::cout << ss.str().size() << ", " << ss.tellg() << ", " << ss.rdbuf()->in_avail() << std::endl;
+    {
+      ss >> w;
+      std::cout << "size: " << ss.str().size() << ", tellg: " << ss.tellg() << ", avail: " << ss.rdbuf()->in_avail() << std::endl;
+      ss >> std::ws;
+      std::cout << "size: " << ss.str().size() << ", tellg: " << ss.tellg() << ", avail: " << ss.rdbuf()->in_avail() << std::endl;
+    }
+    {
+      ss >> w;
+      std::cout << "size: " << ss.str().size() << ", tellg: " << ss.tellg() << ", avail: " << ss.rdbuf()->in_avail() << std::endl;
+      ss >> std::ws;
+      std::cout << "size: " << ss.str().size() << ", tellg: " << ss.tellg() << ", avail: " << ss.rdbuf()->in_avail() << std::endl;
+    }
+    {
+      ss >> w;
+      std::cout << "size: " << ss.str().size() << ", tellg: " << ss.tellg() << ", avail: " << ss.rdbuf()->in_avail() << std::endl;
+      ss >> std::ws;
+      std::cout << "size: " << ss.str().size() << ", tellg: " << ss.tellg() << ", avail: " << ss.rdbuf()->in_avail() << std::endl;
+    }
+    std::cout << ss.str() << std::endl;
+    return 0;
+}

--- a/playground/tmp.cpp
+++ b/playground/tmp.cpp
@@ -9,31 +9,6 @@
 
 int main() {
   /*
-  std::stringstream ss;
-  ss << "hoge\nfuga";
-  std::string line;
-  while (std::getline(ss, line)) {
-    if (ss.eof()) {
-      std::cout << "EOF" << std::endl;
-      ss.seekg(-line.size(), std::ios::cur);
-      break;
-    }
-    std::cout << line << std::endl;
-    std::cout << ss.eof() << std::endl;
-  }
-  std::cout << "----------------" << std::endl;
-  ss << "\n";
-  while (std::getline(ss, line)) {
-    if (ss.eof()) {
-      std::cout << "EOF" << std::endl;
-      ss.seekg(-line.size(), std::ios::cur);
-      break;
-    }
-    std::cout << line << std::endl;
-    std::cout << ss.eof() << std::endl;
-  }
-  */
-  /*
   std::cout << "[" << ss.str() << "]" << std::endl;
   ss.clear();
   ss.str("hoge\nfuga\n");

--- a/srcs/Connection.hpp
+++ b/srcs/Connection.hpp
@@ -78,8 +78,8 @@ class Connection {
       }
     }
     // Finally, check if there is any error while handling the request
-    if (client_socket->get_stl_error()) {
-      Log::info("client_socket->get_stl_error()");
+    if (client_socket->bad()) {
+      Log::info("client_socket->bad()");
       status = DONE;
       return -1;
     }

--- a/srcs/Connection.hpp
+++ b/srcs/Connection.hpp
@@ -114,7 +114,7 @@ class Connection {
     // ss.bad()  : possibly bad alloc
     if (ss.bad()) {
       Log::cfatal() << "ss bad bit is set" << line << std::endl;
-      ErrorHandler::handle(client_socket, 500);
+      ErrorHandler::handle(*client_socket, 500);
       status = RESPONSE;
       return 1;
     }
@@ -122,7 +122,7 @@ class Connection {
     // !ss.eof()  : there are more than 3 tokens or extra white spaces
     if (ss.fail() || !ss.eof()) {
       Log::cinfo() << "Invalid start line: " << line << std::endl;
-      ErrorHandler::handle(client_socket, 400);
+      ErrorHandler::handle(*client_socket, 400);
       status = RESPONSE;
       return 1;
     }
@@ -144,10 +144,10 @@ class Connection {
 
   int handle() throw() {
     if (header.method == "GET") {
-      GetHandler::handle(client_socket, header);
+      GetHandler::handle(*client_socket, header);
     } else {
       Log::cinfo() << "Unsupported method: " << header.method << std::endl;
-      ErrorHandler::handle(client_socket, 405);
+      ErrorHandler::handle(*client_socket, 405);
     }
     status = RESPONSE;
     return 1;

--- a/srcs/ErrorHandler.hpp
+++ b/srcs/ErrorHandler.hpp
@@ -9,41 +9,41 @@
 
 class ErrorHandler {
 public:
-  static void handle(std::shared_ptr<SocketBuf> client_socket, int status_code) throw() {
-  client_socket->clear_sendbuf();
+  static void handle(SocketBuf& client_socket, int status_code) throw() {
+  client_socket.clear_sendbuf();
   switch (status_code) {
     case 400:
-      *client_socket << "temp";
-      *client_socket << "HTTP/1.1 400 Bad Request" << CRLF;
-      *client_socket << "Content-Type: text/html" << CRLF;
-      *client_socket << "Content-Length: " << sizeof(http_error_400_page) << CRLF;
-      *client_socket << CRLF; // end of header
-      *client_socket << http_error_400_page;
-      *client_socket << CRLF; // end of body
+      client_socket << "temp";
+      client_socket << "HTTP/1.1 400 Bad Request" << CRLF;
+      client_socket << "Content-Type: text/html" << CRLF;
+      client_socket << "Content-Length: " << sizeof(http_error_400_page) << CRLF;
+      client_socket << CRLF; // end of header
+      client_socket << http_error_400_page;
+      client_socket << CRLF; // end of body
       break;
     case 404:
-      *client_socket << "HTTP/1.1 404 Resource Not Found" << CRLF;
-      *client_socket << "Content-Type: text/html" << CRLF;
-      *client_socket << "Content-Length: " << sizeof(http_error_404_page) << CRLF;
-      *client_socket << CRLF; // end of header
-      *client_socket << http_error_404_page;
-      *client_socket << CRLF; // end of body
+      client_socket << "HTTP/1.1 404 Resource Not Found" << CRLF;
+      client_socket << "Content-Type: text/html" << CRLF;
+      client_socket << "Content-Length: " << sizeof(http_error_404_page) << CRLF;
+      client_socket << CRLF; // end of header
+      client_socket << http_error_404_page;
+      client_socket << CRLF; // end of body
       break;
     case 405:
-      *client_socket << "HTTP/1.1 405 Method Not Allowed" << CRLF;
-      *client_socket << "Content-Type: text/html" << CRLF;
-      *client_socket << "Content-Length: " << sizeof(http_error_405_page) << CRLF;
-      *client_socket << CRLF; // end of header
-      *client_socket << http_error_405_page;
-      *client_socket << CRLF; // end of body
+      client_socket << "HTTP/1.1 405 Method Not Allowed" << CRLF;
+      client_socket << "Content-Type: text/html" << CRLF;
+      client_socket << "Content-Length: " << sizeof(http_error_405_page) << CRLF;
+      client_socket << CRLF; // end of header
+      client_socket << http_error_405_page;
+      client_socket << CRLF; // end of body
       break;
     case 500:
-      *client_socket << "HTTP/1.1 500 Internal Server Error" << CRLF;
-      *client_socket << "Content-Type: text/html" << CRLF;
-      *client_socket << "Content-Length: " << sizeof(http_error_500_page) << CRLF;
-      *client_socket << CRLF; // end of header
-      *client_socket << http_error_500_page;
-      *client_socket << CRLF; // end of body
+      client_socket << "HTTP/1.1 500 Internal Server Error" << CRLF;
+      client_socket << "Content-Type: text/html" << CRLF;
+      client_socket << "Content-Length: " << sizeof(http_error_500_page) << CRLF;
+      client_socket << CRLF; // end of header
+      client_socket << http_error_500_page;
+      client_socket << CRLF; // end of body
       break;
     default:
       Log::cerror() << "Unknown status code: " << status_code << std::endl;

--- a/srcs/GetHandler.hpp
+++ b/srcs/GetHandler.hpp
@@ -24,10 +24,9 @@ class GetHandler {
   ~GetHandler() throw();                             // Do not implement this
  public:
   // Member functions
-  static void handle(std::shared_ptr<SocketBuf> client_socket,
+  static void handle(SocketBuf& client_socket,
                      const Header& header) throw() {
     // TODO: Write response headers
-    std::stringstream ss;
     ssize_t content_length;
 
     if ((content_length = get_content_length(header.path)) < 0) {
@@ -35,31 +34,30 @@ class GetHandler {
       ErrorHandler::handle(client_socket, 404);
       return;
     }
-    ss << "HTTP/1.1 200 OK" << CRLF;
-    ss << "Server: " << WEBSERV_VER << CRLF;
-    // ss << "Date: Tue, 11 Jul 2023 07:36:50 GMT" << CRLF;
+    client_socket << "HTTP/1.1 200 OK" << CRLF;
+    client_socket << "Server: " << WEBSERV_VER << CRLF;
+    // client_socket << "Date: Tue, 11 Jul 2023 07:36:50 GMT" << CRLF;
     if (util::string::ends_with(header.path, ".css"))
-      ss << "Content-Type: text/css" << CRLF;
+      client_socket << "Content-Type: text/css" << CRLF;
     else if (util::string::ends_with(header.path, ".js"))
-      ss << "Content-Type: text/javascript" << CRLF;
+      client_socket << "Content-Type: text/javascript" << CRLF;
     else if (util::string::ends_with(header.path, ".jpg"))
-      ss << "Content-Type: image/jpeg" << CRLF;
+      client_socket << "Content-Type: image/jpeg" << CRLF;
     else if (util::string::ends_with(header.path, ".png"))
-      ss << "Content-Type: image/png" << CRLF;
+      client_socket << "Content-Type: image/png" << CRLF;
     else if (util::string::ends_with(header.path, ".gif"))
-      ss << "Content-Type: image/gif" << CRLF;
+      client_socket << "Content-Type: image/gif" << CRLF;
     else if (util::string::ends_with(header.path, ".ico"))
-      ss << "Content-Type: image/x-icon" << CRLF;
+      client_socket << "Content-Type: image/x-icon" << CRLF;
     else if (util::string::ends_with(header.path, ".svg"))
-      ss << "Content-Type: image/svg+xml" << CRLF;
+      client_socket << "Content-Type: image/svg+xml" << CRLF;
     else if (util::string::ends_with(header.path, ".html"))
-      ss << "Content-Type: text/html" << CRLF;
+      client_socket << "Content-Type: text/html" << CRLF;
     else
-      ss << "Content-Type: text/plain" << CRLF;
-    ss << "Content-Length: " << content_length << CRLF;
-    ss << CRLF; // end of header
-    client_socket->send(ss.str().c_str(), ss.str().size());
-    if (client_socket->send_file(header.path) < 0) {
+      client_socket << "Content-Type: text/plain" << CRLF;
+    client_socket << "Content-Length: " << content_length << CRLF;
+    client_socket << CRLF; // end of header
+    if (client_socket.send_file(header.path) < 0) {
       Log::error("send_file() failed");
       ErrorHandler::handle(client_socket, 500);
       return;

--- a/srcs/Log.hpp
+++ b/srcs/Log.hpp
@@ -1,3 +1,5 @@
+#ifndef LOG_HPP
+#define LOG_HPP
 #include <fstream>
 #include <iostream>
 
@@ -18,3 +20,4 @@ std::ostream& cwarn() throw();
 std::ostream& cerror() throw();
 std::ostream& cfatal() throw();
 }  // namespace Log
+#endif

--- a/srcs/webserv.hpp
+++ b/srcs/webserv.hpp
@@ -1,6 +1,8 @@
 #ifndef WEBSERV_HPP
 #define WEBSERV_HPP
 
+#define CR '\r'
+#define LF '\n'
 #define CRLF "\r\n"
 #define WEBSERV_VER "webserv/0.0.1"
 #include <stdlib.h>  // exit for now, but should be removed before submission

--- a/tests/unit/SocketBufTests.cpp
+++ b/tests/unit/SocketBufTests.cpp
@@ -1,0 +1,148 @@
+#include "SocketBuf.hpp"
+#include <iostream>
+#include <string>
+
+#define PORT 8282
+
+int server() {
+  // Server socket
+  int listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (listen_fd < 0) {
+    std::cerr << "socket error" << std::endl;
+    exit(1);
+  }
+  sockaddr_in server_addr;
+  server_addr.sin_family = AF_INET;
+  server_addr.sin_port = htons(PORT);
+  server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  int optval = 1;
+  if (setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) < 0) {
+    std::cerr << "setsockopt error" << std::endl;
+    exit(1);
+  }
+  if (bind(listen_fd, (sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
+    std::cerr << "bind error" << std::endl;
+    exit(1);
+  }
+  if (listen(listen_fd, 5) < 0) {
+    std::cerr << "listen error" << std::endl;
+    exit(1);
+  }
+  return listen_fd;
+}
+
+int client() {
+  sockaddr_in server_addr;
+  server_addr.sin_family = AF_INET;
+  server_addr.sin_port = htons(PORT);
+  server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  // Client Socket
+  int client_fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (client_fd < 0) {
+    std::cerr << "socket error" << std::endl;
+    exit(1);
+  }
+  if (connect(client_fd, (sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
+    std::cerr << "connect error" << std::endl;
+    exit(1);
+  }
+  return client_fd;
+}
+
+void T(SocketBuf &sock, const std::string &expected_line, int expected_ret, bool expected_bad, bool expected_closed) {
+  static int cnt = 0;
+  bool ok = true;
+  std::string line;
+  cnt++;
+  std::cout << "Test " << cnt << ": " ;
+  int ret = sock.readline(line);
+  if (line != expected_line) {
+    if (ok) std::cout << "NG" << std::endl;
+    ok = false;
+    std::cerr << "  Expected line: " << expected_line << std::endl;
+    std::cerr << "  Actual line  : " << line << std::endl;
+  }
+  if (ret != expected_ret) {
+    if (ok) std::cout << "NG" << std::endl;
+    ok = false;
+    std::cerr << "  Expected ret: " << expected_ret << std::endl;
+    std::cerr << "  Actual ret  : " << ret << std::endl;
+  }
+  if (sock.bad() != expected_bad) {
+    if (ok) std::cout << "NG" << std::endl;
+    ok = false;
+    std::cerr << "  Expected bad: " << expected_bad << std::endl;
+    std::cerr << "  Actual bad  : " << sock.bad() << std::endl;
+  }
+  if (sock.isClosed() != expected_closed) {
+    if (ok) std::cout << "NG" << std::endl;
+    ok = false;
+    std::cerr << "  Expected closed: " << expected_closed << std::endl;
+    std::cerr << "  Actual closed  : " << sock.isClosed() << std::endl;
+  }
+  if (ok) {
+    std::cout << "OK" << std::endl;
+  }
+}
+
+void send_and_fill(int client_fd, SocketBuf &serv_sock, const std::string &msg) {
+  send(client_fd, msg.c_str(), msg.size(), 0);
+  fd_set readfds;
+  FD_ZERO(&readfds);
+  FD_SET(serv_sock.get_fd(), &readfds);
+  select(serv_sock.get_fd() + 1, &readfds, NULL, NULL, NULL);
+  serv_sock.fill();
+}
+
+void test_socketbuf() {
+  int listen_fd = server(); // Server listen fd
+  int client_fd = client(); // Client fd
+  SocketBuf serv_sock(listen_fd); // Server conn fd wrapper
+  std::string line;
+
+  // 1. Empty
+  T(serv_sock, "", -1, false, false);
+
+  // 2. One line
+  send_and_fill(client_fd, serv_sock, "hello\r\n");
+  T(serv_sock, "hello", 0, false, false);
+  T(serv_sock, "", -1, false, false);
+
+  // 3. Two line
+  send_and_fill(client_fd, serv_sock, "hello\r\nworld\r\n");
+  T(serv_sock, "hello", 0, false, false);
+  T(serv_sock, "world", 0, false, false);
+  T(serv_sock, "", -1, false, false);
+
+  // 4. LF only
+  send_and_fill(client_fd, serv_sock, "hello\n");
+  T(serv_sock, "hello", 0, false, false);
+  T(serv_sock, "", -1, false, false);
+  
+  // 5. CR only
+  send_and_fill(client_fd, serv_sock, "hello\r");
+  T(serv_sock, "hello", 0, false, false);
+  T(serv_sock, "", -1, false, false);
+  
+  // 6. Without CR or LF
+  send_and_fill(client_fd, serv_sock, "hello");
+  T(serv_sock, "", -1, false, false);
+  send_and_fill(client_fd, serv_sock, " world");
+  T(serv_sock, "", -1, false, false);
+  send_and_fill(client_fd, serv_sock, "\r\n");
+  T(serv_sock, "hello world", 0, false, false);
+  T(serv_sock, "", -1, false, false);
+
+  // x. One line + EOF
+  send_and_fill(client_fd, serv_sock, "hello\r\n");
+  shutdown(client_fd, SHUT_WR);
+  T(serv_sock, "hello", 0, false, false);
+  T(serv_sock, "", -1, false, false);
+  serv_sock.fill(); // Notify socket that the peer has closed the connection
+  T(serv_sock, "", -1, false, true);
+}
+
+int main() {
+  Log::setLevel(Log::Warn);
+  test_socketbuf();
+}


### PR DESCRIPTION
SocketBufに使用されているバッファを`vector<char>`から`std::stringstream`に変更しました。
getlineの仕様が難しかった（現在進行形でエラー処理考えると今後の変更も結構難しい）ので簡単なユニットも追加しました。

- SocketBufのユニットテストを追加
- xxxHandlerのhandleメソッドの引数をshard_ptrからreferenceに変更
  - https://stackoverflow.com/questions/1542774/c-reference-to-a-shared-ptr-vs-reference
- 各種playgroundのコードを追加