### PR TITLE
♻️ Refactor/try catch

### DIFF
--- a/srcs/CgiHandler.cpp
+++ b/srcs/CgiHandler.cpp
@@ -7,7 +7,7 @@
 
 #include <cstdlib>  // exit
 
-int CgiHandler::handle(Connection& conn) throw() {
+int CgiHandler::handle(Connection& conn) { // throwable
   // Check if 404
   if (access(conn.header.fullpath.c_str(), F_OK) == -1) {
     ErrorHandler::handle(conn, 404);
@@ -71,15 +71,8 @@ int CgiHandler::handle(Connection& conn) throw() {
   } else {
     // Parent process
     close(cgi_socket[1]);
-    try {
-      conn.cgi_socket =
-          util::shared_ptr<SocketBuf>(new SocketBuf(cgi_socket[0]));
-    } catch (std::exception& e) {
-      Log::fatal("new SocketBuf(cgi_socket[0]) failed");
-      close(cgi_socket[0]);
-      ErrorHandler::handle(conn, 500);
-      return -1;
-    }
+    conn.cgi_socket =
+        util::shared_ptr<SocketBuf>(new SocketBuf(cgi_socket[0])); // throwable
     Log::cdebug() << "body_size: " << conn.body_size;
     conn.cgi_socket->write(conn.body, conn.body_size);
     conn.cgi_pid = pid;

--- a/srcs/CgiHandler.cpp
+++ b/srcs/CgiHandler.cpp
@@ -7,7 +7,7 @@
 
 #include <cstdlib>  // exit
 
-int CgiHandler::handle(Connection& conn) { // throwable
+int CgiHandler::handle(Connection& conn) {  // throwable
   // Check if 404
   if (access(conn.header.fullpath.c_str(), F_OK) == -1) {
     ErrorHandler::handle(conn, 404);
@@ -72,7 +72,7 @@ int CgiHandler::handle(Connection& conn) { // throwable
     // Parent process
     close(cgi_socket[1]);
     conn.cgi_socket =
-        util::shared_ptr<SocketBuf>(new SocketBuf(cgi_socket[0])); // throwable
+        util::shared_ptr<SocketBuf>(new SocketBuf(cgi_socket[0]));  // throwable
     Log::cdebug() << "body_size: " << conn.body_size;
     conn.cgi_socket->write(conn.body, conn.body_size);
     conn.cgi_pid = pid;

--- a/srcs/CgiHandler.hpp
+++ b/srcs/CgiHandler.hpp
@@ -13,7 +13,7 @@ class CgiHandler {
 
  public:
   // Member fuctions
-  static int handle(Connection& conn) throw();
+  static int handle(Connection& conn); // throwable
 };
 
 #endif

--- a/srcs/CgiHandler.hpp
+++ b/srcs/CgiHandler.hpp
@@ -13,7 +13,7 @@ class CgiHandler {
 
  public:
   // Member fuctions
-  static int handle(Connection& conn); // throwable
+  static int handle(Connection& conn);  // throwable
 };
 
 #endif

--- a/srcs/Connection.cpp
+++ b/srcs/Connection.cpp
@@ -7,21 +7,21 @@
 
 #include "DeleteHandler.hpp"
 
-int Connection::resume() { // throwable
+int Connection::resume() {  // throwable
   // 1. Socket I/O
   IOStatus io_status = getIOStatus();
   switch (io_status) {
     case CLIENT_RECV:
-      client_socket->fill(); // throwable
+      client_socket->fill();  // throwable
       break;
     case CLIENT_SEND:
-      client_socket->flush(); // throwable
+      client_socket->flush();  // throwable
       break;
     case CGI_RECV:
-      cgi_socket->fill(); // throwable
+      cgi_socket->fill();  // throwable
       break;
     case CGI_SEND:
-      cgi_socket->flush(); // throwable
+      cgi_socket->flush();  // throwable
       break;
     case NO_IO:
       break;
@@ -49,16 +49,16 @@ int Connection::resume() { // throwable
   while (cont) {
     switch (status) {
       case REQ_START_LINE:
-        cont = parse_start_line(); // throwable
+        cont = parse_start_line();  // throwable
         break;
       case REQ_HEADER_FIELDS:
-        cont = parse_header_fields(); // throwable
+        cont = parse_header_fields();  // throwable
         break;
       case REQ_BODY:
-        cont = parse_body(); // throwable
+        cont = parse_body();  // throwable
         break;
       case HANDLE:
-        cont = handle(); // throwable
+        cont = handle();  // throwable
         break;
       case HANDLE_CGI_REQ:
         cont = handle_cgi_req();
@@ -67,7 +67,7 @@ int Connection::resume() { // throwable
         cont = handle_cgi_res();
         break;
       case HANDLE_CGI_PARSE:
-        cont = handle_cgi_parse(); // throwable
+        cont = handle_cgi_parse();  // throwable
         status = RESPONSE;
         break;
       case RESPONSE:
@@ -134,7 +134,7 @@ Connection::IOStatus Connection::getIOStatus() const throw() {
 int Connection::parse_start_line() {
   std::string line;
 
-  if (client_socket->read_telnet_line(line) < 0) { // throwable
+  if (client_socket->read_telnet_line(line) < 0) {  // throwable
     return 0;
   }
   Log::cdebug() << "start line: " << line << std::endl;
@@ -186,7 +186,7 @@ int Connection::parse_start_line() {
 }
 
 int Connection::split_header_field(const std::string &line, std::string &key,
-                                   std::string &value) { // throwable
+                                   std::string &value) {  // throwable
   std::stringstream ss(line);  // throwable! (bad alloc)
   // 1. Extract key
   if (!std::getline(ss, key, ':')) {  // throwable
@@ -199,13 +199,13 @@ int Connection::split_header_field(const std::string &line, std::string &key,
   // 2. Remove leading space from value
   ss >> std::ws;
   // 3. Extract remaining string to value
-  std::getline(ss, value);     // throwable
+  std::getline(ss, value);  // throwable
   return 0;
 }
 
-int Connection::parse_header_fields() { // throwable
+int Connection::parse_header_fields() {  // throwable
   std::string line;
-  while (client_socket->read_telnet_line(line) == 0) { // throwable
+  while (client_socket->read_telnet_line(line) == 0) {  // throwable
     // Empty line indicates the end of header fields
     if (line == "") {
       status = REQ_BODY;
@@ -214,7 +214,7 @@ int Connection::parse_header_fields() { // throwable
     Log::cdebug() << "header line: " << line << std::endl;
     // Split line to key and value
     std::string key, value;
-    if (split_header_field(line, key, value) < 0) { // throwable
+    if (split_header_field(line, key, value) < 0) {  // throwable
       ErrorHandler::handle(*this, 500);
       status = RESPONSE;
       return 1;
@@ -230,7 +230,7 @@ int Connection::parse_header_fields() { // throwable
   return 0;
 }
 
-int Connection::parse_body() { // throwable
+int Connection::parse_body() {  // throwable
   if (body == NULL) {
     if (header.fields.find("Content-Length") == header.fields.end()) {
       status = HANDLE;
@@ -422,7 +422,7 @@ const config::CgiExtensions *select_cgi_ext_cf(const ConfigItem *cf,
   return NULL;
 }
 
-int Connection::handle() { // throwable
+int Connection::handle() {  // throwable
   srv_cf = select_srv_cf(cf, *this);
   loc_cf = select_loc_cf(srv_cf, header.path);
   cgi_handler_cf = loc_cf ? select_cgi_handler_cf(loc_cf, header.path)
@@ -443,15 +443,16 @@ int Connection::handle() { // throwable
   if (!loc_cf) {
     // Server Root    : Append path to root
     Log::cdebug() << "Server Root" << std::endl;
-    header.fullpath = srv_cf->root + header.path; // throwable
+    header.fullpath = srv_cf->root + header.path;  // throwable
   } else if (!loc_cf->alias.configured) {
     // Location Root  : Append path to root
     Log::cdebug() << "Location Root: " << loc_cf->path << std::endl;
-    header.fullpath = loc_cf->root + header.path; // throwable
+    header.fullpath = loc_cf->root + header.path;  // throwable
   } else {
     // Location Alias : Replace prefix with alias
     Log::cdebug() << "Location Alias: " << loc_cf->path << std::endl;
-    header.fullpath = loc_cf->alias + header.path.substr(loc_cf->path.size()); // throwable
+    header.fullpath =
+        loc_cf->alias + header.path.substr(loc_cf->path.size());  // throwable
   }
 
   // `limit_except` directive
@@ -476,16 +477,16 @@ int Connection::handle() { // throwable
   }
   // If not CGI
   if (header.method == "GET") {
-    GetHandler::handle(*this); // throwable
+    GetHandler::handle(*this);  // throwable
   } else if (header.method == "POST") {
-    PostHandler::handle(*this); // throwable
+    PostHandler::handle(*this);  // throwable
   } else if (header.method == "PUT") {
-    PostHandler::handle(*this); // throwable
+    PostHandler::handle(*this);  // throwable
   } else if (header.method == "DELETE") {
     DeleteHandler::handle(*this);
   } else {
     Log::cinfo() << "Unsupported method: " << header.method << std::endl;
-    ErrorHandler::handle(*this, 405); // throwable
+    ErrorHandler::handle(*this, 405);  // throwable
   }
   status = RESPONSE;
   return 1;
@@ -578,12 +579,12 @@ int Connection::handle_cgi_res() throw() {
 // status-code    = "200" | "302" | "400" | "501" | extension-code
 // extension-code = 3digit
 // reason-phrase  = *TEXT
-int Connection::handle_cgi_parse() { // throwable
+int Connection::handle_cgi_parse() {  // throwable
   // TODO: parse
   std::string line;
   // Read header fields
   std::map<std::string, std::string> cgi_header_fields;
-  while (cgi_socket->readline(line) == 0) { // throwable
+  while (cgi_socket->readline(line) == 0) {  // throwable
     Log::cdebug() << "CGI line: " << line << std::endl;
     // Empty line indicates the end of header fields
     if (line == "" || line == "\r") {

--- a/srcs/Connection.cpp
+++ b/srcs/Connection.cpp
@@ -15,13 +15,13 @@ int Connection::resume() { // throwable
       client_socket->fill();
       break;
     case CLIENT_SEND:
-      client_socket->flush();
+      client_socket->flush(); // throwable
       break;
     case CGI_RECV:
       cgi_socket->fill();
       break;
     case CGI_SEND:
-      cgi_socket->flush();
+      cgi_socket->flush(); // throwable
       break;
     case NO_IO:
       break;

--- a/srcs/Connection.cpp
+++ b/srcs/Connection.cpp
@@ -49,7 +49,7 @@ int Connection::resume() { // throwable
   while (cont) {
     switch (status) {
       case REQ_START_LINE:
-        cont = parse_start_line();
+        cont = parse_start_line(); // throwable
         break;
       case REQ_HEADER_FIELDS:
         cont = parse_header_fields(); // throwable
@@ -58,7 +58,7 @@ int Connection::resume() { // throwable
         cont = parse_body(); // throwable
         break;
       case HANDLE:
-        cont = handle();
+        cont = handle(); // throwable
         break;
       case HANDLE_CGI_REQ:
         cont = handle_cgi_req();
@@ -131,10 +131,10 @@ Connection::IOStatus Connection::getIOStatus() const throw() {
 // TODO: make this noexcept
 // https://datatracker.ietf.org/doc/html/rfc2616#section-5.1
 // Request-Line   = Method SP Request-URI SP HTTP-Version CRLF
-int Connection::parse_start_line() throw() {
+int Connection::parse_start_line() {
   std::string line;
 
-  if (client_socket->read_telnet_line(line) < 0) {
+  if (client_socket->read_telnet_line(line) < 0) { // throwable
     return 0;
   }
   Log::cdebug() << "start line: " << line << std::endl;
@@ -205,7 +205,7 @@ int Connection::split_header_field(const std::string &line, std::string &key,
 
 int Connection::parse_header_fields() { // throwable
   std::string line;
-  while (client_socket->read_telnet_line(line) == 0) {
+  while (client_socket->read_telnet_line(line) == 0) { // throwable
     // Empty line indicates the end of header fields
     if (line == "") {
       status = REQ_BODY;

--- a/srcs/Connection.cpp
+++ b/srcs/Connection.cpp
@@ -476,16 +476,16 @@ int Connection::handle() { // throwable
   }
   // If not CGI
   if (header.method == "GET") {
-    GetHandler::handle(*this);
+    GetHandler::handle(*this); // throwable
   } else if (header.method == "POST") {
-    PostHandler::handle(*this);
+    PostHandler::handle(*this); // throwable
   } else if (header.method == "PUT") {
-    PostHandler::handle(*this);
+    PostHandler::handle(*this); // throwable
   } else if (header.method == "DELETE") {
     DeleteHandler::handle(*this);
   } else {
     Log::cinfo() << "Unsupported method: " << header.method << std::endl;
-    ErrorHandler::handle(*this, 405);
+    ErrorHandler::handle(*this, 405); // throwable
   }
   status = RESPONSE;
   return 1;

--- a/srcs/Connection.cpp
+++ b/srcs/Connection.cpp
@@ -67,7 +67,7 @@ int Connection::resume() { // throwable
         cont = handle_cgi_res();
         break;
       case HANDLE_CGI_PARSE:
-        cont = handle_cgi_parse();
+        cont = handle_cgi_parse(); // throwable
         status = RESPONSE;
         break;
       case RESPONSE:
@@ -578,12 +578,12 @@ int Connection::handle_cgi_res() throw() {
 // status-code    = "200" | "302" | "400" | "501" | extension-code
 // extension-code = 3digit
 // reason-phrase  = *TEXT
-int Connection::handle_cgi_parse() throw() {
+int Connection::handle_cgi_parse() { // throwable
   // TODO: parse
   std::string line;
   // Read header fields
   std::map<std::string, std::string> cgi_header_fields;
-  while (cgi_socket->readline(line) == 0) {
+  while (cgi_socket->readline(line) == 0) { // throwable
     Log::cdebug() << "CGI line: " << line << std::endl;
     // Empty line indicates the end of header fields
     if (line == "" || line == "\r") {

--- a/srcs/Connection.cpp
+++ b/srcs/Connection.cpp
@@ -12,13 +12,13 @@ int Connection::resume() { // throwable
   IOStatus io_status = getIOStatus();
   switch (io_status) {
     case CLIENT_RECV:
-      client_socket->fill();
+      client_socket->fill(); // throwable
       break;
     case CLIENT_SEND:
       client_socket->flush(); // throwable
       break;
     case CGI_RECV:
-      cgi_socket->fill();
+      cgi_socket->fill(); // throwable
       break;
     case CGI_SEND:
       cgi_socket->flush(); // throwable

--- a/srcs/Connection.hpp
+++ b/srcs/Connection.hpp
@@ -151,7 +151,7 @@ class Connection {
   // status-code    = "200" | "302" | "400" | "501" | extension-code
   // extension-code = 3digit
   // reason-phrase  = *TEXT
-  int handle_cgi_parse() throw();
+  int handle_cgi_parse(); // throwable
 
   int response() throw();
 };

--- a/srcs/Connection.hpp
+++ b/srcs/Connection.hpp
@@ -86,7 +86,7 @@ class Connection {
 
   // Member functions
   // Returns negative value when an exception is thrown from STL containers
-  int resume() throw();
+  int resume();
   int clear();
 
   IOStatus getIOStatus() const throw();
@@ -99,11 +99,11 @@ class Connection {
   int split_header_field(const std::string &line, std::string &key,
                          std::string &value);
 
-  int parse_header_fields() throw();
+  int parse_header_fields();
 
-  int parse_body() throw();
+  int parse_body();
 
-  int handle() throw();
+  int handle();
 
   int handle_cgi_req() throw();
 

--- a/srcs/Connection.hpp
+++ b/srcs/Connection.hpp
@@ -94,16 +94,16 @@ class Connection {
   // TODO: make this noexcept
   // https://datatracker.ietf.org/doc/html/rfc2616#section-5.1
   // Request-Line   = Method SP Request-URI SP HTTP-Version CRLF
-  int parse_start_line() throw();
+  int parse_start_line(); // throwable
 
   int split_header_field(const std::string &line, std::string &key,
-                         std::string &value);
+                         std::string &value); // throwable
 
-  int parse_header_fields();
+  int parse_header_fields(); // throwable
 
-  int parse_body();
+  int parse_body(); // throwable
 
-  int handle();
+  int handle(); // throwable
 
   int handle_cgi_req() throw();
 

--- a/srcs/Connection.hpp
+++ b/srcs/Connection.hpp
@@ -94,16 +94,16 @@ class Connection {
   // TODO: make this noexcept
   // https://datatracker.ietf.org/doc/html/rfc2616#section-5.1
   // Request-Line   = Method SP Request-URI SP HTTP-Version CRLF
-  int parse_start_line(); // throwable
+  int parse_start_line();  // throwable
 
   int split_header_field(const std::string &line, std::string &key,
-                         std::string &value); // throwable
+                         std::string &value);  // throwable
 
-  int parse_header_fields(); // throwable
+  int parse_header_fields();  // throwable
 
-  int parse_body(); // throwable
+  int parse_body();  // throwable
 
-  int handle(); // throwable
+  int handle();  // throwable
 
   int handle_cgi_req() throw();
 
@@ -151,7 +151,7 @@ class Connection {
   // status-code    = "200" | "302" | "400" | "501" | extension-code
   // extension-code = 3digit
   // reason-phrase  = *TEXT
-  int handle_cgi_parse(); // throwable
+  int handle_cgi_parse();  // throwable
 
   int response() throw();
 };

--- a/srcs/ErrorHandler.cpp
+++ b/srcs/ErrorHandler.cpp
@@ -55,7 +55,7 @@ const config::ErrorPage* find_error_page(const ConfigItem* cf,
 #define ERR_403 2
 #define ERR_404 3
 #define ERR_500 4
-int try_error_page(Connection& conn, int status_code) { // throwable
+int try_error_page(Connection& conn, int status_code) {  // throwable
   // 1. No context for error_page
   if (!conn.loc_cf && !conn.srv_cf) {
     return -1;
@@ -108,12 +108,11 @@ int try_error_page(Connection& conn, int status_code) { // throwable
   //
 }
 
-void ErrorHandler::handle(Connection& conn, int status_code,
-                          bool noredirect) {
+void ErrorHandler::handle(Connection& conn, int status_code, bool noredirect) {
   conn.client_socket->clear_sendbuf();
   // Error Page by `error_page` directive
   if (!noredirect) {
-    if (try_error_page(conn, status_code) == 0) { // throwable
+    if (try_error_page(conn, status_code) == 0) {  // throwable
       return;
     }
   }

--- a/srcs/ErrorHandler.cpp
+++ b/srcs/ErrorHandler.cpp
@@ -55,7 +55,7 @@ const config::ErrorPage* find_error_page(const ConfigItem* cf,
 #define ERR_403 2
 #define ERR_404 3
 #define ERR_500 4
-int try_error_page(Connection& conn, int status_code) throw() {
+int try_error_page(Connection& conn, int status_code) { // throwable
   // 1. No context for error_page
   if (!conn.loc_cf && !conn.srv_cf) {
     return -1;
@@ -75,14 +75,7 @@ int try_error_page(Connection& conn, int status_code) throw() {
   std::string path;
   const config::Server* srv_cf = conn.srv_cf;
   const config::Location* loc_cf = select_loc_cf(conn.srv_cf, error_page->uri);
-  try {
-    ret = resolve_path(srv_cf, loc_cf, error_page->uri, path, st);
-  } catch (const std::exception& e) {
-    Log::cfatal() << "Error page path resolution failed: " << e.what()
-                  << std::endl;
-    ErrorHandler::handle(conn, 500, true);
-    return 0;
-  }
+  ret = resolve_path(srv_cf, loc_cf, error_page->uri, path, st);
 
   if (ret == ERR_500) {
     ErrorHandler::handle(conn, 500, true);
@@ -116,11 +109,11 @@ int try_error_page(Connection& conn, int status_code) throw() {
 }
 
 void ErrorHandler::handle(Connection& conn, int status_code,
-                          bool noredirect) throw() {
+                          bool noredirect) {
   conn.client_socket->clear_sendbuf();
   // Error Page by `error_page` directive
   if (!noredirect) {
-    if (try_error_page(conn, status_code) == 0) {
+    if (try_error_page(conn, status_code) == 0) { // throwable
       return;
     }
   }

--- a/srcs/ErrorHandler.hpp
+++ b/srcs/ErrorHandler.hpp
@@ -8,6 +8,6 @@ class Connection;
 class ErrorHandler {
  public:
   static void handle(Connection& conn, int status_code,
-                     bool noredirect = false) throw();
+                     bool noredirect = false); // throwable
 };
 #endif

--- a/srcs/ErrorHandler.hpp
+++ b/srcs/ErrorHandler.hpp
@@ -8,6 +8,6 @@ class Connection;
 class ErrorHandler {
  public:
   static void handle(Connection& conn, int status_code,
-                     bool noredirect = false); // throwable
+                     bool noredirect = false);  // throwable
 };
 #endif

--- a/srcs/GetHandler.cpp
+++ b/srcs/GetHandler.cpp
@@ -13,7 +13,7 @@
 
 void send_regular_file(Connection& conn, const std::string& path,
                        size_t content_length) throw();
-void send_directory_listing(Connection& conn, const std::string& path) throw();
+void send_directory_listing(Connection& conn, const std::string& path);
 
 #define OK_FILE 0
 #define OK_DIR 1
@@ -87,7 +87,7 @@ int resolve_path(const config::Server* srv_cf, const config::Location* loc_cf,
   return ERR_404;
 }
 
-void GetHandler::handle(Connection& conn) throw() {
+void GetHandler::handle(Connection& conn) { // throwable
   // TODO: Write response headers
   struct stat st;
   std::string path;
@@ -100,7 +100,7 @@ void GetHandler::handle(Connection& conn) throw() {
   } else if (response_type == ERR_403) {
     ErrorHandler::handle(conn, 403);
   } else if (response_type == OK_DIR) {
-    send_directory_listing(conn, path);
+    send_directory_listing(conn, path); // throwable
   } else if (response_type == OK_FILE) {
     send_regular_file(conn, path, st.st_size);
   } else {

--- a/srcs/GetHandler.cpp
+++ b/srcs/GetHandler.cpp
@@ -87,7 +87,7 @@ int resolve_path(const config::Server* srv_cf, const config::Location* loc_cf,
   return ERR_404;
 }
 
-void GetHandler::handle(Connection& conn) { // throwable
+void GetHandler::handle(Connection& conn) {  // throwable
   // TODO: Write response headers
   struct stat st;
   std::string path;
@@ -100,7 +100,7 @@ void GetHandler::handle(Connection& conn) { // throwable
   } else if (response_type == ERR_403) {
     ErrorHandler::handle(conn, 403);
   } else if (response_type == OK_DIR) {
-    send_directory_listing(conn, path); // throwable
+    send_directory_listing(conn, path);  // throwable
   } else if (response_type == OK_FILE) {
     send_regular_file(conn, path, st.st_size);
   } else {

--- a/srcs/GetHandler.hpp
+++ b/srcs/GetHandler.hpp
@@ -14,6 +14,6 @@ class GetHandler {
   ~GetHandler() throw();                             // Do not implement this
  public:
   // Member functions
-  static void handle(Connection& conn) throw();
+  static void handle(Connection& conn); // throwable
 };
 #endif

--- a/srcs/GetHandler.hpp
+++ b/srcs/GetHandler.hpp
@@ -14,6 +14,6 @@ class GetHandler {
   ~GetHandler() throw();                             // Do not implement this
  public:
   // Member functions
-  static void handle(Connection& conn); // throwable
+  static void handle(Connection& conn);  // throwable
 };
 #endif

--- a/srcs/PostHandler.cpp
+++ b/srcs/PostHandler.cpp
@@ -13,7 +13,7 @@
 
 // This is throwable
 template <typename ConfigItem>
-static int internal_handle(Connection& conn, ConfigItem* cf) { // throwable
+static int internal_handle(Connection& conn, ConfigItem* cf) {  // throwable
   // `upload_store` directive
   if (!cf->upload_store.configured) return ERR_405;
   // `client_max_body_size` directive
@@ -39,7 +39,7 @@ static int internal_handle(Connection& conn, ConfigItem* cf) { // throwable
       Log::fatal("stringstream failed while generating filename");
       return ERR_500;
     }
-    filename = ss.str(); // throwable
+    filename = ss.str();  // throwable
     filepath = cf->upload_store + "/" + filename;
   } while (access(filename.c_str(), F_OK) != -1);
 
@@ -83,9 +83,9 @@ static int internal_handle(Connection& conn, ConfigItem* cf) { // throwable
 void PostHandler::handle(Connection& conn) {
   int err;
   if (conn.loc_cf) {
-    err = internal_handle(conn, conn.loc_cf); // throwable
+    err = internal_handle(conn, conn.loc_cf);  // throwable
   } else {
-    err = internal_handle(conn, conn.srv_cf); // throwable
+    err = internal_handle(conn, conn.srv_cf);  // throwable
   }
   switch (err) {
     case SUCCESS:

--- a/srcs/PostHandler.hpp
+++ b/srcs/PostHandler.hpp
@@ -24,7 +24,7 @@ class PostHandler {
 
  public:
   // Member fuctions
-  static void handle(Connection& conn); // throwable
+  static void handle(Connection& conn);  // throwable
 };
 
 #endif

--- a/srcs/PostHandler.hpp
+++ b/srcs/PostHandler.hpp
@@ -24,7 +24,7 @@ class PostHandler {
 
  public:
   // Member fuctions
-  static void handle(Connection& conn) throw();
+  static void handle(Connection& conn); // throwable
 };
 
 #endif

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -23,7 +23,7 @@ int Server::getaddrinfo(const config::Listen& l, struct addrinfo** result) {
   const char* host = (l.address == "*") ? NULL : l.address.c_str();
   std::stringstream ss;
   ss << l.port;
-  if (ss.bad()) {
+  if (ss.fail()) {
     return -1;
   }
   std::string port(ss.str());  // throwable

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -19,15 +19,14 @@ Server::Server(const config::Config& cf) throw()
   FD_ZERO(&writefds);
 }
 
-int Server::getaddrinfo(const config::Listen& l, struct addrinfo **result) {
-  const char* host =
-      (l.address == "*") ? NULL : l.address.c_str();
+int Server::getaddrinfo(const config::Listen& l, struct addrinfo** result) {
+  const char* host = (l.address == "*") ? NULL : l.address.c_str();
   std::stringstream ss;
   ss << l.port;
   if (ss.bad()) {
     return -1;
   }
-  std::string port(ss.str()); // throwable
+  std::string port(ss.str());  // throwable
   struct addrinfo hints;
 
   memset(&hints, 0, sizeof(struct addrinfo));
@@ -58,13 +57,13 @@ int Server::getaddrinfo(const config::Listen& l, struct addrinfo **result) {
 }
 
 int Server::listen(const config::Listen& l) {
-  struct addrinfo *result;
-  if (getaddrinfo(l, &result) < 0) { // throwable
+  struct addrinfo* result;
+  if (getaddrinfo(l, &result) < 0) {  // throwable
     return -1;
   }
   /* Walk through returned list until we find an address structure
    * that can be used to successfully connect a socket */
-  for (struct addrinfo *rp = result; rp != NULL; rp = rp->ai_next) {
+  for (struct addrinfo* rp = result; rp != NULL; rp = rp->ai_next) {
     Log::cdebug() << "listen : " << l << std::endl;
     Log::cdebug() << "ip: " << rp << std::endl;
     int sfd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
@@ -73,7 +72,7 @@ int Server::listen(const config::Listen& l) {
                     << ")" << std::endl;
       return -1;
     }
-    util::shared_ptr<Socket> sock(new Socket(sfd)); // throwable
+    util::shared_ptr<Socket> sock(new Socket(sfd));  // throwable
     if (sock->reuseaddr() < 0) {
       Log::cfatal() << "sock.set_reuseaddr() failed. (" << errno << ": "
                     << strerror(errno) << ")" << std::endl;
@@ -105,13 +104,13 @@ int Server::listen(const config::Listen& l) {
     // Save the listening ip address to config::Listen
     // Here we use const_cast to modify the const object.
     {
-      config::Listen& ll = const_cast<config::Listen &>(l);
+      config::Listen& ll = const_cast<config::Listen&>(l);
       memcpy(&ll.addr, rp->ai_addr, rp->ai_addrlen);
       ll.addrlen = rp->ai_addrlen;
     }
     FD_SET(sock->get_fd(), &readfds);
     maxfd = std::max(maxfd, sock->get_fd());
-    listen_socks.push_back(sock); // throwable
+    listen_socks.push_back(sock);  // throwable
     break;  // Success, one socket per one listen directive
   }
   freeaddrinfo(result);
@@ -124,7 +123,7 @@ void Server::startup() {
     const config::Server& server = cf.http.servers[i];
     for (unsigned int j = 0; j < server.listens.size(); ++j) {
       Log::cdebug() << "j: " << j << std::endl;
-      if (listen(server.listens[j]) < 0) { // throwable
+      if (listen(server.listens[j]) < 0) {  // throwable
         std::exit(EXIT_FAILURE);
       }
     }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -254,17 +254,22 @@ void Server::resume(util::shared_ptr<Connection> conn) throw() {
   try {
     conn->resume();  // throwable
   } catch (std::exception& e) {
+    // We don't send 500 error page to keep our life simple.
     remove_connection(conn);
+    return;
   }
+  // If the connection is aborted, remove it.
   if (conn->is_remove()) {
     Log::info("connection aborted");
     remove_connection(conn);
     return;
   }
+  // If the request is done, clear it.
   if (conn->is_clear()) {
     Log::info("Request is done, clear connection");
     conn->clear();
   }
+  // Update fdset
   update_fdset(conn);
 }
 

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -13,117 +13,119 @@ std::ostream& operator<<(std::ostream& os, const struct addrinfo* rp);
 
 Server::~Server() throw() {}
 
-Server::Server(const config::Config& cf)
+Server::Server(const config::Config& cf) throw()
     : maxfd(-1), listen_socks(), connections(), cf(cf) {
   FD_ZERO(&readfds);
   FD_ZERO(&writefds);
-  int backlog = BACKLOG;
+}
+
+int Server::getaddrinfo(const config::Listen& l, struct addrinfo **result) {
+  const char* host =
+      (l.address == "*") ? NULL : l.address.c_str();
+  std::stringstream ss;
+  ss << l.port;
+  if (ss.bad()) {
+    return -1;
+  }
+  std::string port(ss.str()); // throwable
+  struct addrinfo hints;
+
+  memset(&hints, 0, sizeof(struct addrinfo));
+  hints.ai_canonname = NULL;
+  hints.ai_addr = NULL;
+  hints.ai_next = NULL;
+  // TODO: AF_INET or AF_INET6 depends on the address format
+  // i.e. "192.168.1.1"                             -> AF_INET
+  //      "*"                                       -> AF_INET
+  //      "localhost"                               -> AF_INET
+  //      "google.com"                              -> AF_INET
+  //      "[::]"                                    -> AF_INET6
+  //      "[::1]"                                   -> AF_INET6
+  //      "2001:0db8:85a3:0000:0000:8a2e:0370:7334" -> AF_INET6
+
+  hints.ai_family = AF_UNSPEC; /* Allows IPv4 or IPv6 */
+  if (l.address == "*") {
+    hints.ai_family = AF_INET; /* Allows IPv4 only */
+  }
+  hints.ai_flags = AI_PASSIVE; /* Wildcard IP address */
+  hints.ai_socktype = SOCK_STREAM;
+
+  int error = ::getaddrinfo(host, port.c_str(), &hints, result);
+  if (error) {
+    return -1;
+  }
+  return 0;
+}
+
+int Server::listen(const config::Listen& l) {
+  struct addrinfo *result;
+  if (getaddrinfo(l, &result) < 0) { // throwable
+    return -1;
+  }
+  /* Walk through returned list until we find an address structure
+   * that can be used to successfully connect a socket */
+  for (struct addrinfo *rp = result; rp != NULL; rp = rp->ai_next) {
+    Log::cdebug() << "listen : " << l << std::endl;
+    Log::cdebug() << "ip: " << rp << std::endl;
+    int sfd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+    if (sfd == -1) {
+      Log::cfatal() << "socket() failed. (" << errno << ": " << strerror(errno)
+                    << ")" << std::endl;
+      return -1;
+    }
+    util::shared_ptr<Socket> sock(new Socket(sfd)); // throwable
+    if (sock->reuseaddr() < 0) {
+      Log::cfatal() << "sock.set_reuseaddr() failed. (" << errno << ": "
+                    << strerror(errno) << ")" << std::endl;
+      return -1;
+    }
+    if (rp->ai_family == AF_INET6) {
+      if (sock->ipv6only() < 0) {
+        Log::cfatal() << "sock.set_ipv6only() failed. (" << errno << ": "
+                      << strerror(errno) << ")" << std::endl;
+        return -1;
+      }
+    }
+    if (sock->bind(rp->ai_addr, rp->ai_addrlen) < 0) {
+      Log::cfatal() << "bind to " << rp << ":" << l.port << " failed."
+                    << "(" << errno << ": " << strerror(errno) << ")"
+                    << std::endl;
+      return -1;
+    }
+    if (sock->listen(BACKLOG) < 0) {
+      Log::cfatal() << "sock.listen() failed. (" << errno << ": "
+                    << strerror(errno) << ")" << std::endl;
+      return -1;
+    }
+    if (sock->set_nonblock() < 0) {
+      Log::cfatal() << "sock.set_nonblock() failed. (" << errno << ": "
+                    << strerror(errno) << ")" << std::endl;
+      return -1;
+    }
+    // Save the listening ip address to config::Listen
+    // Here we use const_cast to modify the const object.
+    {
+      config::Listen& ll = const_cast<config::Listen &>(l);
+      memcpy(&ll.addr, rp->ai_addr, rp->ai_addrlen);
+      ll.addrlen = rp->ai_addrlen;
+    }
+    FD_SET(sock->get_fd(), &readfds);
+    maxfd = std::max(maxfd, sock->get_fd());
+    listen_socks.push_back(sock); // throwable
+    break;  // Success, one socket per one listen directive
+  }
+  freeaddrinfo(result);
+  return 0;
+}
+
+void Server::startup() {
   for (unsigned int i = 0; i < cf.http.servers.size(); ++i) {
     Log::cdebug() << "i: " << i << std::endl;
     const config::Server& server = cf.http.servers[i];
     for (unsigned int j = 0; j < server.listens.size(); ++j) {
       Log::cdebug() << "j: " << j << std::endl;
-      const config::Listen& listen = server.listens[j];
-      const char* host =
-          (listen.address == "*") ? NULL : listen.address.c_str();
-      int port = listen.port;
-      std::stringstream ss;
-      ss << port;
-      std::string port_str = ss.str();
-      const char* service = port_str.c_str();
-      int type = SOCK_STREAM;
-      {
-        struct addrinfo hints;
-        struct addrinfo *result, *rp;
-        int sfd, s;
-
-        Log::debug("memset()");
-        memset(&hints, 0, sizeof(struct addrinfo));
-        hints.ai_canonname = NULL;
-        hints.ai_addr = NULL;
-        hints.ai_next = NULL;
-        // TODO: AF_INET or AF_INET6 depends on the address format
-        // i.e. "192.168.1.1"                             -> AF_INET
-        //      "*"                                       -> AF_INET
-        //      "localhost"                               -> AF_INET
-        //      "google.com"                              -> AF_INET
-        //      "[::]"                                    -> AF_INET6
-        //      "[::1]"                                   -> AF_INET6
-        //      "2001:0db8:85a3:0000:0000:8a2e:0370:7334" -> AF_INET6
-
-        hints.ai_family = AF_UNSPEC; /* Allows IPv4 or IPv6 */
-        if (listen.address == "*") {
-          hints.ai_family = AF_INET; /* Allows IPv4 only */
-        }
-        hints.ai_flags = AI_PASSIVE; /* Wildcard IP address */
-        hints.ai_socktype = type;
-
-        Log::debug("getaddrinfo()");
-        s = getaddrinfo(host, service, &hints, &result);
-        if (s != 0) {
-          errno = ENOSYS;
-          throw std::runtime_error("getaddrinfo() failed");
-        }
-
-        /* Walk through returned list until we find an address structure
-         * that can be used to successfully connect a socket */
-        for (rp = result; rp != NULL; rp = rp->ai_next) {
-          sfd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
-          if (sfd == -1) {
-            Log::error("socket() failed");
-            continue; /* On error, try next address */
-          }
-          // Don't handle exception to close the socket, because if the
-          // construct of sock fails, Server can't be constructed and thus the
-          // program terminates.
-          util::shared_ptr<Socket> sock(new Socket(sfd));
-          if (sock->reuseaddr() < 0) {
-            throw std::runtime_error("sock.set_reuseaddr() failed");
-          }
-          Log::cdebug() << "listen : " << listen << std::endl;
-          /* convert ai_addr from binary to string */
-          Log::cdebug() << "ip: " << rp << std::endl;
-          // IPv6 socket listening on a wildcard address [::] will accept only
-          // IPv6 connections Without this option, it will accept both IPv4 and
-          // IPv6 connections
-          if (rp->ai_family == AF_INET6) {
-            sock->ipv6only();
-          }
-          if (sock->bind(rp->ai_addr, rp->ai_addrlen) < 0) {
-            // If wildcard address, it's possible IPv6 socket is already
-            // bound to IPv4 wildcard address. In that case, bind() fails.
-            // https://www.geekpage.jp/blog/?id=2017-3-8-1
-            //
-            // This case is not an error, so we continue to try other
-            if (errno == EADDRINUSE) {
-              Log::cdebug() << "EADDRINUSE" << std::endl;
-              continue;
-            }
-            // Other case, such as invalid address, is an error
-            Log::cfatal() << "bind to " << rp << ":" << port << " failed."
-                          << "(" << errno << ": " << strerror(errno) << ")"
-                          << std::endl;
-            throw std::runtime_error("sock.bind() failed");
-          }
-          if (sock->listen(backlog) < 0) {
-            throw std::runtime_error("sock.listen() failed");
-          }
-          if (sock->set_nonblock() < 0) {
-            throw std::runtime_error("sock.set_nonblock() failed");
-          }
-          // Save the listening ip address to config::Listen
-          // Here we use const_cast to modify the const object.
-          {
-            memcpy(const_cast<struct sockaddr_storage*>(&listen.addr),
-                   rp->ai_addr, rp->ai_addrlen);
-            const_cast<socklen_t&>(listen.addrlen) = rp->ai_addrlen;
-          }
-          FD_SET(sock->get_fd(), &readfds);
-          maxfd = std::max(maxfd, sock->get_fd());
-          listen_socks.push_back(sock);
-          break;  // Success, one socket per one listen directive
-        }
-        freeaddrinfo(result);
+      if (listen(server.listens[j]) < 0) { // throwable
+        std::exit(EXIT_FAILURE);
       }
     }
   }
@@ -131,8 +133,8 @@ Server::Server(const config::Config& cf)
 
 void Server::remove_connection(
     util::shared_ptr<Connection> connection) throw() {
-  connections.erase(
-      std::find(connections.begin(), connections.end(), connection));
+  connections.erase(std::find(connections.begin(), connections.end(),
+                              connection));  // no throw
   FD_CLR(connection->get_fd(), &readfds);
   FD_CLR(connection->get_fd(), &writefds);
   if (connection->get_cgifd() != -1) {
@@ -160,6 +162,7 @@ void Server::remove_all_connections() throw() {
     maxfd = std::max(maxfd, (*it)->get_fd());
   }
 }
+
 void Server::accept(util::shared_ptr<Socket> sock) throw() {
   try {
     util::shared_ptr<Connection> conn(
@@ -171,6 +174,7 @@ void Server::accept(util::shared_ptr<Socket> sock) throw() {
     Log::cerror() << "Server::accept() failed: " << e.what() << std::endl;
   }
 }
+
 void Server::update_fdset(util::shared_ptr<Connection> conn) throw() {
   FD_CLR(conn->get_fd(), &readfds);
   FD_CLR(conn->get_fd(), &writefds);
@@ -226,14 +230,16 @@ bool Server::canResume(util::shared_ptr<Connection> conn) const throw() {
       return false;
   }
 }
-util::shared_ptr<Socket> Server::get_ready_socket() throw() {
+
+util::shared_ptr<Socket> Server::get_ready_listen_socket() throw() {
   for (SockIterator it = listen_socks.begin(); it != listen_socks.end(); ++it) {
     if (FD_ISSET((*it)->get_fd(), &ready_rfds)) {
       return *it;
     }
   }
-  return util::shared_ptr<Socket>(NULL);
+  return util::shared_ptr<Socket>();
 }
+
 // Logically it is not const because it returns a non-const pointer.
 util::shared_ptr<Connection> Server::get_ready_connection() throw() {
   // TODO: equally distribute the processing time to each connection
@@ -242,30 +248,38 @@ util::shared_ptr<Connection> Server::get_ready_connection() throw() {
       return *it;
     }
   }
-  return util::shared_ptr<Connection>(NULL);
+  return util::shared_ptr<Connection>();
 }
-void Server::process() throw() {
-  if (wait() < 0) {
+
+void Server::resume(util::shared_ptr<Connection> conn) throw() {
+  try {
+    conn->resume();  // throwable
+  } catch (std::exception& e) {
+    remove_connection(conn);
+  }
+  if (conn->is_remove()) {
+    Log::info("connection aborted");
+    remove_connection(conn);
     return;
   }
-  util::shared_ptr<Connection> conn;
-  util::shared_ptr<Socket> sock;
-  if ((sock = get_ready_socket()) != NULL) {
-    accept(sock);
-  } else if ((conn = get_ready_connection()) != NULL) {
-    if (conn->resume() < 0) {
-      Log::cerror() << "connection aborted" << std::endl;
-      remove_connection(conn);
-      return;
+  if (conn->is_clear()) {
+    Log::info("Request is done, clear connection");
+    conn->clear();
+  }
+  update_fdset(conn);
+}
+
+void Server::run() throw() {
+  while (1) {
+    if (wait() < 0) {
+      continue;
     }
-    if (conn->is_remove()) {
-      Log::info("connection done");
-      remove_connection(conn);
-    } else if (conn->is_clear()) {
-      conn->clear();
-      update_fdset(conn);
-    } else {
-      update_fdset(conn);
+    util::shared_ptr<Connection> conn;  // no throw
+    util::shared_ptr<Socket> sock;      // no throw
+    if ((sock = get_ready_listen_socket()) != NULL) {
+      accept(sock);  // no throw
+    } else if ((conn = get_ready_connection()) != NULL) {
+      resume(conn);  // no throw
     }
   }
 }

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -13,6 +13,7 @@ class Connection;
 class Socket;
 namespace config {
 class Config;
+class Listen;
 }
 
 class Server {
@@ -25,23 +26,35 @@ class Server {
   fd_set ready_rfds, ready_wfds;
   int maxfd;
 
+ private:
+  Server() throw();  // Do not implement
+
  public:
+  // Constructor/Destructor
+  Server(const config::Config& cf) throw();
+  ~Server() throw();
+
+  // Member functions
+  void startup();  // throwable
+  void run() throw();
+
+ private:
   // Member data
   SockVector listen_socks;
   ConnVector connections;
   const config::Config& cf;
 
-  // Constructor/Destructor
-  Server() throw();  // Do not implement this
-  Server(const config::Config& cf);
-  ~Server() throw();
-
   // Member functions
+  int getaddrinfo(const config::Listen& l, struct addrinfo **result); // throwable
+  int listen(const config::Listen& l); // throwable
+
   void remove_connection(util::shared_ptr<Connection> connection) throw();
 
   void remove_all_connections() throw();
 
   void accept(util::shared_ptr<Socket> sock) throw();
+
+  void resume(util::shared_ptr<Connection> conn) throw();
 
   void update_fdset(util::shared_ptr<Connection> conn) throw();
 
@@ -49,12 +62,10 @@ class Server {
 
   bool canResume(util::shared_ptr<Connection> conn) const throw();
 
-  util::shared_ptr<Socket> get_ready_socket() throw();
+  util::shared_ptr<Socket> get_ready_listen_socket() throw();
 
   // Logically it is not const because it returns a non-const pointer.
   util::shared_ptr<Connection> get_ready_connection() throw();
-
-  void process() throw();
 };
 
 #endif

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -14,7 +14,7 @@ class Socket;
 namespace config {
 class Config;
 class Listen;
-}
+}  // namespace config
 
 class Server {
  private:
@@ -45,8 +45,9 @@ class Server {
   const config::Config& cf;
 
   // Member functions
-  int getaddrinfo(const config::Listen& l, struct addrinfo **result); // throwable
-  int listen(const config::Listen& l); // throwable
+  int getaddrinfo(const config::Listen& l,
+                  struct addrinfo** result);  // throwable
+  int listen(const config::Listen& l);        // throwable
 
   void remove_connection(util::shared_ptr<Connection> connection) throw();
 

--- a/srcs/Socket.hpp
+++ b/srcs/Socket.hpp
@@ -140,7 +140,7 @@ class Socket {
   // However, it has a basic guarantee that it will not leak fd
   //  std::runtime_error if accept() failed
   //  std::bad_alloc if new Socket() failed
-  util::shared_ptr<Socket> accept() { // throwable
+  util::shared_ptr<Socket> accept() {  // throwable
     struct sockaddr_storage caddr;
     socklen_t caddrlen = sizeof(caddr);
     int connfd = ::accept(fd, (struct sockaddr*)&caddr, &caddrlen);

--- a/srcs/Socket.hpp
+++ b/srcs/Socket.hpp
@@ -137,9 +137,10 @@ class Socket {
   }
 
   // This is a kind of constructor, so it is THROWABLE
+  // However, it has a basic guarantee that it will not leak fd
   //  std::runtime_error if accept() failed
   //  std::bad_alloc if new Socket() failed
-  util::shared_ptr<Socket> accept() {
+  util::shared_ptr<Socket> accept() { // throwable
     struct sockaddr_storage caddr;
     socklen_t caddrlen = sizeof(caddr);
     int connfd = ::accept(fd, (struct sockaddr*)&caddr, &caddrlen);
@@ -161,7 +162,7 @@ class Socket {
                      saddrlen, caddrlen));
       // connsock->set_nolinger(0);
       return connsock;
-    } catch (std::bad_alloc& e) {
+    } catch (std::exception& e) {
       Log::error("new Socket() failed");
       if (::close(connfd) < 0) {
         Log::error("close() failed");

--- a/srcs/SocketBuf.cpp
+++ b/srcs/SocketBuf.cpp
@@ -31,24 +31,17 @@ int SocketBuf::send_file(const std::string& filepath) throw() {
   }
   return 0;
 }
-int SocketBuf::readline(std::string& line) throw() {
+int SocketBuf::readline(std::string& line) {
   StreamCleaner _(rss, wss);
   if (bad()) {
     return -1;
   }
   // 1. getline
-  try {
-    // If there is an error while getline, return -1
-    // i.e. str.max_size() characters have been stored.
-    if (!std::getline(rss, line)) {  // throwable
-      Log::debug("std::getline(LF) failed");
-      line.clear();
-      return -1;
-    }
-  } catch (std::exception& e) {
-    Log::fatal("getline() failed");
+  // If there is an error while getline, return -1
+  // i.e. str.max_size() characters have been stored.
+  if (!std::getline(rss, line)) {  // throwable
+    Log::debug("std::getline(LF) failed");
     line.clear();
-    setbadstate();
     return -1;
   }
 

--- a/srcs/SocketBuf.cpp
+++ b/srcs/SocketBuf.cpp
@@ -56,7 +56,7 @@ int SocketBuf::readline(std::string& line) {
   Log::debug("LF found");
   return 0;
 }
-int SocketBuf::read_telnet_line(std::string& line) { // throwable
+int SocketBuf::read_telnet_line(std::string& line) {  // throwable
   StreamCleaner _(rss, wss);
   if (bad()) {
     return -1;
@@ -116,7 +116,7 @@ int SocketBuf::flush() {
     Log::cerror() << "wss.tellg() failed\n";
     return -1;
   }
-  std::string buf(wss.str()); // throwable
+  std::string buf(wss.str());  // throwable
   // TODO: buf may contain unnecessary leading data, we need to remove them
 
 #ifdef LINUX
@@ -137,7 +137,7 @@ int SocketBuf::flush() {
   wss.seekg(ret, std::ios::cur);
   return ret;
 }
-int SocketBuf::fill() { // throwable
+int SocketBuf::fill() {  // throwable
   StreamCleaner _(rss, wss);
   if (bad()) {
     return -1;
@@ -154,7 +154,7 @@ int SocketBuf::fill() { // throwable
     socket->beClosed();
   }
   // Fill ret bytes buf into rss
-  std::string s(buf, ret); // throwable
+  std::string s(buf, ret);  // throwable
   rss << s;
   return ret;
 }

--- a/srcs/SocketBuf.cpp
+++ b/srcs/SocketBuf.cpp
@@ -137,7 +137,7 @@ int SocketBuf::flush() {
   wss.seekg(ret, std::ios::cur);
   return ret;
 }
-int SocketBuf::fill() throw() {
+int SocketBuf::fill() { // throwable
   StreamCleaner _(rss, wss);
   if (bad()) {
     return -1;
@@ -154,15 +154,9 @@ int SocketBuf::fill() throw() {
     socket->beClosed();
   }
   // Fill ret bytes buf into rss
-  try {
-    std::string s(buf, ret);
-    rss << s;
-    return ret;
-  } catch (std::exception& e) {
-    Log::fatal("std::string(buf, ret) failed");
-    setbadstate();
-    return -1;
-  }
+  std::string s(buf, ret); // throwable
+  rss << s;
+  return ret;
 }
 SocketBuf& SocketBuf::write(const char* buf, size_t size) throw() {
   StreamCleaner _(rss, wss);

--- a/srcs/SocketBuf.cpp
+++ b/srcs/SocketBuf.cpp
@@ -56,24 +56,17 @@ int SocketBuf::readline(std::string& line) {
   Log::debug("LF found");
   return 0;
 }
-int SocketBuf::read_telnet_line(std::string& line) throw() {
+int SocketBuf::read_telnet_line(std::string& line) { // throwable
   StreamCleaner _(rss, wss);
   if (bad()) {
     return -1;
   }
   // 1. getline
-  try {
-    // If there is an error while getline, return -1
-    // i.e. str.max_size() characters have been stored.
-    if (!std::getline(rss, line, LF)) {  // throwable
-      Log::debug("std::getline(LF) failed");
-      line.clear();
-      return -1;
-    }
-  } catch (std::exception& e) {
-    Log::fatal("getline() failed");
+  // If there is an error while getline, return -1
+  // i.e. str.max_size() characters have been stored.
+  if (!std::getline(rss, line, LF)) {  // throwable
+    Log::debug("std::getline(LF) failed");
     line.clear();
-    setbadstate();
     return -1;
   }
   // 2. EOF before LF (i.e. no LF found)

--- a/srcs/SocketBuf.hpp
+++ b/srcs/SocketBuf.hpp
@@ -78,7 +78,7 @@ class SocketBuf {
   int flush(); // throwable
 
   // Actually receive data from socket
-  int fill() throw();
+  int fill(); // throwable
 
   void clear_sendbuf() throw() {
     wss.str("");

--- a/srcs/SocketBuf.hpp
+++ b/srcs/SocketBuf.hpp
@@ -66,7 +66,7 @@ class SocketBuf {
   }
   int send_file(const std::string& filepath) throw();
 
-  int readline(std::string& line); // throwable
+  int readline(std::string& line);  // throwable
 
   // Read line from buffer, if found, remove it from buffer and return 0
   // Otherwise, return -1
@@ -75,10 +75,10 @@ class SocketBuf {
   ssize_t read(char* buf, size_t size) throw();
 
   // Actually send data on socket
-  int flush(); // throwable
+  int flush();  // throwable
 
   // Actually receive data from socket
-  int fill(); // throwable
+  int fill();  // throwable
 
   void clear_sendbuf() throw() {
     wss.str("");

--- a/srcs/SocketBuf.hpp
+++ b/srcs/SocketBuf.hpp
@@ -70,7 +70,7 @@ class SocketBuf {
 
   // Read line from buffer, if found, remove it from buffer and return 0
   // Otherwise, return -1
-  int read_telnet_line(std::string& line) throw();
+  int read_telnet_line(std::string& line);
 
   ssize_t read(char* buf, size_t size) throw();
 

--- a/srcs/SocketBuf.hpp
+++ b/srcs/SocketBuf.hpp
@@ -75,7 +75,7 @@ class SocketBuf {
   ssize_t read(char* buf, size_t size) throw();
 
   // Actually send data on socket
-  int flush() throw();
+  int flush(); // throwable
 
   // Actually receive data from socket
   int fill() throw();

--- a/srcs/SocketBuf.hpp
+++ b/srcs/SocketBuf.hpp
@@ -66,7 +66,7 @@ class SocketBuf {
   }
   int send_file(const std::string& filepath) throw();
 
-  int readline(std::string& line) throw();
+  int readline(std::string& line); // throwable
 
   // Read line from buffer, if found, remove it from buffer and return 0
   // Otherwise, return -1

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -23,10 +23,8 @@ int main(int argc, char *argv[]) {
     Log::fatal("signal() failed");
     return ERROR;
   }
-  // Starting servers can throw exceptions, but after the start-up process,
-  // the servers will not throw exceptions.
   try {
-    run_server(argv[1]); // throwable
+    run_server(argv[1]);  // throwable
     return 0;
   } catch (std::exception &e) {
     Log::cfatal() << "Caught exception while starting server: " << e.what();
@@ -34,27 +32,31 @@ int main(int argc, char *argv[]) {
   }
 }
 
+// Starting servers can throw exceptions, but after the start-up process,
+// the servers will not throw exceptions.
 void run_server(char *filename) {
   // Construct Config from config file.
-  config::Config cf; // throwable
+  config::Config cf;  // throwable
   if (filename) {
     std::ifstream ifs(filename);
     if (!ifs.is_open()) {
       throw std::runtime_error("Cannot open config file");
     }
     std::string s((std::istreambuf_iterator<char>(ifs)),
-                  std::istreambuf_iterator<char>()); // no throw
-    Token *tokens = tokenize(s); // throwable
-    Module *mod = parse(tokens); // throwable
-    cf = config::Config(mod); // throwable
+                  std::istreambuf_iterator<char>());  // no throw
+    Token *tokens = tokenize(s);                      // throwable
+    Module *mod = parse(tokens);                      // throwable
+    cf = config::Config(mod);                         // throwable
     delete mod;
     delete tokens;
   }
+  // Print config
   config::print(cf);
 
-  // Start server.
-  Server server(cf); // throwable
-  while (1) {
-    server.process(); // no throw
-  }
+  // Start up server
+  Server server(cf); // no throw
+  server.startup(); // throwable
+
+  // Run server
+  server.run();  // no throw, never return
 }

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -24,8 +24,8 @@ int main(int argc, char *argv[]) {
     return ERROR;
   }
   try {
-    run_server(argv[1]); // throwable
-    return ERROR; // if startup is successful, this line is unreachable
+    run_server(argv[1]);  // throwable
+    return ERROR;         // if startup is successful, this line is unreachable
   } catch (std::exception &e) {
     Log::cfatal() << "Caught exception while starting server: " << e.what();
     return ERROR;
@@ -54,10 +54,10 @@ int run_server(char *filename) {
   config::print(cf);
 
   // Start up server
-  Server server(cf); // no throw
-  server.startup(); // throwable
+  Server server(cf);  // no throw
+  server.startup();   // throwable
 
   // Run server
   server.run();  // no throw
-  return -1; // unreachable, never return
+  return -1;     // unreachable, never return
 }

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -7,7 +7,7 @@
 #define PORT 8181
 #define ERROR 1
 
-void run_server(char *filename);
+int run_server(char *filename);
 
 int main(int argc, char *argv[]) {
 #ifdef DEBUG
@@ -24,8 +24,8 @@ int main(int argc, char *argv[]) {
     return ERROR;
   }
   try {
-    run_server(argv[1]);  // throwable
-    return 0;
+    run_server(argv[1]); // throwable
+    return ERROR; // if startup is successful, this line is unreachable
   } catch (std::exception &e) {
     Log::cfatal() << "Caught exception while starting server: " << e.what();
     return ERROR;
@@ -34,13 +34,13 @@ int main(int argc, char *argv[]) {
 
 // Starting servers can throw exceptions, but after the start-up process,
 // the servers will not throw exceptions.
-void run_server(char *filename) {
+int run_server(char *filename) {
   // Construct Config from config file.
   config::Config cf;  // throwable
   if (filename) {
     std::ifstream ifs(filename);
     if (!ifs.is_open()) {
-      throw std::runtime_error("Cannot open config file");
+      return -1;
     }
     std::string s((std::istreambuf_iterator<char>(ifs)),
                   std::istreambuf_iterator<char>());  // no throw
@@ -58,5 +58,6 @@ void run_server(char *filename) {
   server.startup(); // throwable
 
   // Run server
-  server.run();  // no throw, never return
+  server.run();  // no throw
+  return -1; // unreachable, never return
 }

--- a/srcs/send_directory_listing.cpp
+++ b/srcs/send_directory_listing.cpp
@@ -11,68 +11,65 @@ static int compar(const struct dirent** s1, const struct dirent** s2) {
     return strcmp((*s1)->d_name, (*s2)->d_name);
 }
 
-void send_directory_listing(Connection& conn, const std::string& path) throw() {
+void send_directory_listing(Connection& conn, const std::string& path) { // throwable
+  // Generate HTML for directory listing
+  std::stringstream ss;
+  ss << "<html>" << CRLF << "<head><title>Index of " << conn.header.path
+     << "</title></head>" << CRLF << "<body>" << CRLF << "<h1>Index of "
+     << conn.header.path << "</h1><hr><pre>";
+  struct dirent **dirlist, *dp;
+  int r = scandir(path.c_str(), &dirlist, NULL, compar);
+  if (r < 0) {
+    Log::error("scandir() failed");
+    ErrorHandler::handle(conn, 500);
+    return;
+  }
+  ss << "<a href=\"../\">../</a>" << CRLF;
+  for (int i = 0; i < r; ++i) {
+    dp = dirlist[i];
+    struct stat st;
+    if (stat((path + dp->d_name).c_str(), &st) < 0) {
+      Log::error("stat() failed");
+      ErrorHandler::handle(conn, 500);
+      return;
+    }
+    if (strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0)
+      continue;
+    // Name with link
+    ss << "<a href=\"" << dp->d_name;
+    if (S_ISDIR(st.st_mode)) ss << "/";
+    ss << "\">";
+    ss << dp->d_name;
+    if (S_ISDIR(st.st_mode)) ss << "/";
+    ss << "</a>";
+
+    // Date time with space aligned
+    ss << std::setw(68 - strlen(dp->d_name) - (S_ISDIR(st.st_mode) ? 1 : 0));
+    char buf[256];
+    struct tm* tm = localtime(&st.st_mtime);
+    strftime(buf, sizeof(buf), "%d-%b-%Y %H:%M", tm);
+    ss << buf;
+
+    // Size with space aligned
+    ss << std::setw(20) << std::right;
+    if (S_ISDIR(st.st_mode))
+      ss << "-";
+    else
+      ss << st.st_size;
+    ss << CRLF;
+  }
+  free(dirlist);
+  ss << "</pre><hr></body>" << CRLF << "</html>" << CRLF;
+  if (ss.fail()) {
+    Log::error("stringstream::fail() == true");
+    ErrorHandler::handle(conn, 500);
+    return;
+  }
+  // Send Response
   *conn.client_socket << "HTTP/1.1 200 OK" << CRLF;
   *conn.client_socket << "Server: " << WEBSERV_VER << CRLF;
   *conn.client_socket << "Content-Type: text/html" << CRLF;
-  std::stringstream ss;
-  try {
-    ss << "<html>" << CRLF << "<head><title>Index of " << conn.header.path
-       << "</title></head>" << CRLF << "<body>" << CRLF << "<h1>Index of "
-       << conn.header.path << "</h1><hr><pre>";
-    struct dirent **dirlist, *dp;
-    int r = scandir(path.c_str(), &dirlist, NULL, compar);
-    if (r < 0) {
-      Log::error("scandir() failed");
-      ErrorHandler::handle(conn, 500);
-      return;
-    }
-    ss << "<a href=\"../\">../</a>" << CRLF;
-    for (int i = 0; i < r; ++i) {
-      dp = dirlist[i];
-      struct stat st;
-      if (stat((path + dp->d_name).c_str(), &st) < 0) {
-        Log::error("stat() failed");
-        ErrorHandler::handle(conn, 500);
-        return;
-      }
-      if (strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0)
-        continue;
-      // Name with link
-      ss << "<a href=\"" << dp->d_name;
-      if (S_ISDIR(st.st_mode)) ss << "/";
-      ss << "\">";
-      ss << dp->d_name;
-      if (S_ISDIR(st.st_mode)) ss << "/";
-      ss << "</a>";
-
-      // Date time with space aligned
-      ss << std::setw(68 - strlen(dp->d_name) - (S_ISDIR(st.st_mode) ? 1 : 0));
-      char buf[256];
-      struct tm* tm = localtime(&st.st_mtime);
-      strftime(buf, sizeof(buf), "%d-%b-%Y %H:%M", tm);
-      ss << buf;
-
-      // Size with space aligned
-      ss << std::setw(20) << std::right;
-      if (S_ISDIR(st.st_mode))
-        ss << "-";
-      else
-        ss << st.st_size;
-      ss << CRLF;
-    }
-    free(dirlist);
-    ss << "</pre><hr></body>" << CRLF << "</html>" << CRLF;
-    if (ss.fail()) {
-      Log::error("stringstream::fail() == true");
-      ErrorHandler::handle(conn, 500);
-      return;
-    }
-    *conn.client_socket << "Content-Length: " << ss.str().length() << CRLF;
-    *conn.client_socket << CRLF;  // end of header
-    *conn.client_socket << ss.str();
-  } catch (std::exception& e) {
-    Log::cerror() << "std::exception: " << std::string(e.what());
-    ErrorHandler::handle(conn, 500);
-  }
+  *conn.client_socket << "Content-Length: " << ss.str().length() << CRLF;
+  *conn.client_socket << CRLF;  // end of header
+  *conn.client_socket << ss.str(); // throwable
 }

--- a/srcs/send_directory_listing.cpp
+++ b/srcs/send_directory_listing.cpp
@@ -11,7 +11,8 @@ static int compar(const struct dirent** s1, const struct dirent** s2) {
     return strcmp((*s1)->d_name, (*s2)->d_name);
 }
 
-void send_directory_listing(Connection& conn, const std::string& path) { // throwable
+void send_directory_listing(Connection& conn,
+                            const std::string& path) {  // throwable
   // Generate HTML for directory listing
   std::stringstream ss;
   ss << "<html>" << CRLF << "<head><title>Index of " << conn.header.path
@@ -33,8 +34,7 @@ void send_directory_listing(Connection& conn, const std::string& path) { // thro
       ErrorHandler::handle(conn, 500);
       return;
     }
-    if (strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0)
-      continue;
+    if (strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0) continue;
     // Name with link
     ss << "<a href=\"" << dp->d_name;
     if (S_ISDIR(st.st_mode)) ss << "/";
@@ -70,6 +70,6 @@ void send_directory_listing(Connection& conn, const std::string& path) { // thro
   *conn.client_socket << "Server: " << WEBSERV_VER << CRLF;
   *conn.client_socket << "Content-Type: text/html" << CRLF;
   *conn.client_socket << "Content-Length: " << ss.str().length() << CRLF;
-  *conn.client_socket << CRLF;  // end of header
-  *conn.client_socket << ss.str(); // throwable
+  *conn.client_socket << CRLF;      // end of header
+  *conn.client_socket << ss.str();  // throwable
 }

--- a/srcs/util.cpp
+++ b/srcs/util.cpp
@@ -13,7 +13,7 @@ std::string util::path::get_extension(const std::string& filepath) {
   if (pos == std::string::npos) {
     return "";
   }
-  return filepath.substr(pos); // throwable
+  return filepath.substr(pos);  // throwable
 }
 
 // https://tools.ietf.org/html/rfc7230#section-3.2.6

--- a/srcs/util.cpp
+++ b/srcs/util.cpp
@@ -13,7 +13,7 @@ std::string util::path::get_extension(const std::string& filepath) {
   if (pos == std::string::npos) {
     return "";
   }
-  return filepath.substr(pos);
+  return filepath.substr(pos); // throwable
 }
 
 // https://tools.ietf.org/html/rfc7230#section-3.2.6

--- a/srcs/util.hpp
+++ b/srcs/util.hpp
@@ -29,8 +29,8 @@ class shared_ptr {
       }
     }
   }
-  shared_ptr() : ptr(), ref_count(NULL), d(Deleter<T>()) {}
-  shared_ptr(T* ptr) : ptr(ptr), ref_count(new int), d(Deleter<T>()) {
+  shared_ptr() throw() : ptr(), ref_count(NULL), d(Deleter<T>()) {}
+  explicit shared_ptr(T* ptr) : ptr(ptr), ref_count(new int), d(Deleter<T>()) {
     *ref_count = 1;
   }
   shared_ptr(const shared_ptr<T>& other)


### PR DESCRIPTION
全ての関数をnoexcept保証するのをやめます。

基本方針は以下です。
1. try/catchとthrowの使用を極力少なくする
2. catchの中で使用する関数はnoexcept保証する（`throw()）


try/catchを使うのは、以下の4箇所のみとします
1. サーバーの初期化のtry/catch -> exit
2. conn.resume()のtry/catch -> remove_connection
3. server.accept()のtry/catch -> 何もしない
4. Socketのaccept内でのnewのtry/catch -> close(fd) : 例外安全の基本保証をするため