### PR TITLE
✨ Feat/keepalive timeout (Fix #59)

### DIFF
--- a/srcs/CgiHandler.cpp
+++ b/srcs/CgiHandler.cpp
@@ -12,7 +12,8 @@
 int CgiHandler::handle(Connection& conn) {  // throwable
   std::string script_path = conn.header.fullpath;
   std::string dir_path = script_path.substr(0, script_path.find_last_of('/'));
-  std::string script_name = script_path.substr(script_path.find_last_of('/') + 1);
+  std::string script_name =
+      script_path.substr(script_path.find_last_of('/') + 1);
   // Check if 404
   if (access(script_path.c_str(), F_OK) == -1) {
     ErrorHandler::handle(conn, 404);

--- a/srcs/Connection.cpp
+++ b/srcs/Connection.cpp
@@ -758,3 +758,73 @@ int Connection::response() throw() {
   }
   return 0;
 }
+
+bool Connection::is_timeout() const throw() {
+  return (time(NULL) - last_modified) > TIMEOUT_SEC;
+}
+
+bool Connection::is_cgi_timeout() const throw() {
+  switch (status) {
+    case HANDLE_CGI_REQ:
+    case HANDLE_CGI_RES:
+      break;
+    default:
+      return false;
+  }
+  return (time(NULL) - cgi_started) > CGI_TIMEOUT_SEC;
+}
+
+int Connection::kill_and_reap_cgi_process() throw() {
+  // Already handled
+  if (cgi_pid <= 0) {
+    return -1;
+  }
+
+  // Kill the cgi process
+  if (kill(cgi_pid, SIGKILL) < 0) {
+    Log::cerror() << "kill failed. (" << errno << ": " << strerror(errno) << ")"
+                  << std::endl;
+    return -1;
+  }
+
+  // Wait for CGI process to terminate
+  pid_t ret;
+  int exit_status;
+  Log::cdebug() << "waitpid(" << cgi_pid << ")" << std::endl;
+  while ((ret = waitpid(cgi_pid, &exit_status, WNOHANG)) <= 0) {
+    if (ret == 0) {
+      // If CGI process is still running, continue to waitpid
+      // This is possible because of the timelag between kill() and actual
+      // termination of CGI process
+      continue;
+    }
+    // If interrupted by signal, continue to waitpid again
+    if (errno == EINTR) continue;
+    // Other errors(ECHILD/EFAULT/EINVAL), return 500
+    // I don't think this will happen though.
+    Log::cfatal() << "waitpid failed. (" << errno << ": " << strerror(errno)
+                  << ")" << std::endl;
+    cgi_pid = -1;
+    return -1;
+  }
+  Log::cdebug() << "waitpid(" << cgi_pid << ") returns " << ret << std::endl;
+  cgi_pid = -1;
+  return exit_status;
+}
+
+void Connection::handle_cgi_timeout() throw() {
+  Log::info("CGI timeout");
+  // Already handled
+  if (cgi_pid == -1) {
+    return;
+  }
+  // kill cgi process
+  if (kill_and_reap_cgi_process() < 0) {
+    Log::cfatal() << "kill_and_reap_cgi_process failed" << std::endl;
+    ErrorHandler::handle(*this, 500);
+    status = RESPONSE;
+    return;
+  }
+  ErrorHandler::handle(*this, 504);
+  status = RESPONSE;
+}

--- a/srcs/Connection.cpp
+++ b/srcs/Connection.cpp
@@ -8,6 +8,8 @@
 #include "DeleteHandler.hpp"
 
 int Connection::resume() {  // throwable
+  Log::debug("Connection::resume()");
+  last_modified = time(NULL);
   // 1. Socket I/O
   switch (io_status) {
     case CLIENT_RECV:

--- a/srcs/Connection.hpp
+++ b/srcs/Connection.hpp
@@ -16,6 +16,8 @@
 #include "SocketBuf.hpp"
 #include "webserv.hpp"
 
+#define TIMEOUT_SEC 10
+
 class Connection {
  public:
   // Class private enum
@@ -59,6 +61,7 @@ class Connection {
   const config::Location *loc_cf;
   const config::CgiHandler *cgi_handler_cf;
   const config::CgiExtensions *cgi_ext_cf;
+  time_t last_modified;
 
  public:
   IOStatus io_status;
@@ -77,6 +80,7 @@ class Connection {
         cf(cf),
         srv_cf(NULL),
         loc_cf(NULL),
+        last_modified(time(NULL)),
         io_status(NO_IO) {}
   ~Connection() throw() {}
   Connection(const Connection &other) throw();  // Do not implement this
@@ -91,6 +95,9 @@ class Connection {
   }
   bool is_remove() const throw() { return status == DONE; }
   bool is_clear() const throw() { return status == CLEAR; }
+  bool is_timeout() const throw() {
+    return (time(NULL) - last_modified) > TIMEOUT_SEC;
+  }
 
   // Member functions
   // Returns negative value when an exception is thrown from STL containers

--- a/srcs/Connection.hpp
+++ b/srcs/Connection.hpp
@@ -97,74 +97,10 @@ class Connection {
   }
   bool is_remove() const throw() { return status == DONE; }
   bool is_clear() const throw() { return status == CLEAR; }
-  bool is_timeout() const throw() {
-    return (time(NULL) - last_modified) > TIMEOUT_SEC;
-  }
-  bool is_cgi_timeout() const throw() {
-    switch (status) {
-      case HANDLE_CGI_REQ:
-      case HANDLE_CGI_RES:
-        break;
-      default:
-        return false;
-    }
-    return (time(NULL) - cgi_started) > CGI_TIMEOUT_SEC;
-  }
-
-  int kill_and_reap_cgi_process() throw() {
-    // Already handled
-    if (cgi_pid <= 0) {
-      return -1;
-    }
-
-    // Kill the cgi process
-    if (kill(cgi_pid, SIGKILL) < 0) {
-      Log::cerror() << "kill failed. (" << errno << ": " << strerror(errno)
-                    << ")" << std::endl;
-      return -1;
-    }
-
-    // Wait for CGI process to terminate
-    pid_t ret;
-    int exit_status;
-    Log::cdebug() << "waitpid(" << cgi_pid << ")" << std::endl;
-    while ((ret = waitpid(cgi_pid, &exit_status, WNOHANG)) <= 0) {
-      if (ret == 0) {
-        // If CGI process is still running, continue to waitpid
-        // This is possible because of the timelag between kill() and actual
-        // termination of CGI process
-        continue;
-      }
-      // If interrupted by signal, continue to waitpid again
-      if (errno == EINTR) continue;
-      // Other errors(ECHILD/EFAULT/EINVAL), return 500
-      // I don't think this will happen though.
-      Log::cfatal() << "waitpid failed. (" << errno << ": " << strerror(errno)
-                    << ")" << std::endl;
-      cgi_pid = -1;
-      return -1;
-    }
-    Log::cdebug() << "waitpid(" << cgi_pid << ") returns " << ret << std::endl;
-    cgi_pid = -1;
-    return exit_status;
-  }
-  void handle_cgi_timeout() throw() {
-    Log::info("CGI timeout");
-    // Already handled
-    if (cgi_pid == -1) {
-      return;
-    }
-    // kill cgi process
-    if (kill_and_reap_cgi_process() < 0) {
-      Log::cfatal() << "kill_and_reap_cgi_process failed" << std::endl;
-      ErrorHandler::handle(*this, 500);
-      status = RESPONSE;
-      return;
-    }
-    ErrorHandler::handle(*this, 504);
-    status = RESPONSE;
-  }
-
+  bool is_timeout() const throw();
+  bool is_cgi_timeout() const throw();
+  int kill_and_reap_cgi_process() throw();
+  void handle_cgi_timeout() throw();
   // Member functions
   // Returns negative value when an exception is thrown from STL containers
   int resume();

--- a/srcs/ErrorHandler.cpp
+++ b/srcs/ErrorHandler.cpp
@@ -28,6 +28,8 @@ const char* status_line(int status_code) throw() {
       return "HTTP/1.1 413 Request Entity Too Large";
     case 500:
       return "HTTP/1.1 500 Internal Server Error";
+    case 504:
+      return "HTTP/1.1 504 Gateway Timeout";
     default:
       Log::cfatal() << "Unknown status code: " << status_code << std::endl;
       return "HTTP/1.1 500 Internal Server Error";
@@ -169,6 +171,14 @@ void ErrorHandler::handle(Connection& conn, int status_code, bool noredirect) {
                           << sizeof(http_error_500_page) - 1 << CRLF;
       *conn.client_socket << CRLF;  // end of header
       *conn.client_socket << http_error_500_page;
+      break;
+    case 504:
+      *conn.client_socket << "HTTP/1.1 504 Gateway Timeout" << CRLF;
+      *conn.client_socket << "Content-Type: text/html" << CRLF;
+      *conn.client_socket << "Content-Length: "
+                          << sizeof(http_error_504_page) - 1 << CRLF;
+      *conn.client_socket << CRLF;  // end of header
+      *conn.client_socket << http_error_504_page;
       break;
     default:
       Log::cerror() << "Unknown status code: " << status_code << std::endl;

--- a/srcs/RedirectHandler.cpp
+++ b/srcs/RedirectHandler.cpp
@@ -7,5 +7,6 @@ void RedirectHandler::handle(const Connection& conn, int status_code,
   *conn.client_socket << "HTTP/1.1 " << status_code << " Moved Permanently"
                       << CRLF;
   *conn.client_socket << "Location: " << location << CRLF;
+  *conn.client_socket << "Content-Length: 0" << CRLF;
   *conn.client_socket << CRLF;
 }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -161,6 +161,7 @@ Server::ConnIterator Server::remove_connection(
   return it;
 }
 void Server::remove_timeout_connections() throw() {
+  last_timeout_check = time(NULL);
   for (ConnIterator it = connections.begin(); it != connections.end();) {
     if ((*it)->is_cgi_timeout()) {
       Log::cinfo() << "CGI timeout: connfd(" << (*it)->get_fd() << ")"
@@ -227,7 +228,7 @@ int Server::wait() throw() {
     Log::cerror() << "select error: " << strerror(errno) << std::endl;
     return -1;
   }
-  if (result == 0) {
+  if (result == 0 || (time(NULL) - last_timeout_check) > std::min(TIMEOUT_SEC, CGI_TIMEOUT_SEC)) {
     remove_timeout_connections();
     return -1;
   }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -137,10 +137,11 @@ void Server::startup() {
   }
 }
 
-void Server::remove_connection(
+Server::ConnIterator Server::remove_connection(
     util::shared_ptr<Connection> connection) throw() {
-  connections.erase(std::find(connections.begin(), connections.end(),
-                              connection));  // no throw
+  ConnIterator it =
+      connections.erase(std::find(connections.begin(), connections.end(),
+                                  connection));  // no throw
   FD_CLR(connection->get_fd(), &readfds);
   FD_CLR(connection->get_fd(), &writefds);
   if (connection->get_cgifd() != -1) {
@@ -157,15 +158,19 @@ void Server::remove_connection(
       maxfd = std::max(maxfd, (*it)->get_fd());
     }
   }
+  return it;
 }
-void Server::remove_all_connections() throw() {
-  connections.clear();
-  FD_ZERO(&readfds);
-  FD_ZERO(&writefds);
-  maxfd = -1;
-  for (SockIterator it = listen_socks.begin(); it != listen_socks.end(); ++it) {
-    FD_SET((*it)->get_fd(), &readfds);
-    maxfd = std::max(maxfd, (*it)->get_fd());
+void Server::remove_timeout_connections() throw() {
+  for (ConnIterator it = connections.begin(); it != connections.end();) {
+    if ((*it)->is_timeout()) {
+      Log::cinfo() << "Connection timeout: connfd(" << (*it)->get_fd() << ")"
+                   << " port("
+                   << (*it)->client_socket->socket->get_client_port() << ")"
+                   << std::endl;
+      it = remove_connection(*it);  // always returns the next iterator
+    } else {
+      ++it;
+    }
   }
 }
 
@@ -207,14 +212,15 @@ void Server::update_fdset(util::shared_ptr<Connection> conn) throw() {
 int Server::wait() throw() {
   ready_rfds = this->readfds;
   ready_wfds = this->writefds;
-  int result = ::select(maxfd + 1, &ready_rfds, &ready_wfds, NULL, NULL);
+  // timeout 1s
+  struct timeval timeout = {.tv_sec = 1, .tv_usec = 0};
+  int result = ::select(maxfd + 1, &ready_rfds, &ready_wfds, NULL, &timeout);
   if (result < 0) {
     Log::cerror() << "select error: " << strerror(errno) << std::endl;
     return -1;
   }
   if (result == 0) {
-    Log::info("select timeout");
-    remove_all_connections();
+    remove_timeout_connections();
     return -1;
   }
   return 0;

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -162,7 +162,13 @@ Server::ConnIterator Server::remove_connection(
 }
 void Server::remove_timeout_connections() throw() {
   for (ConnIterator it = connections.begin(); it != connections.end();) {
-    if ((*it)->is_timeout()) {
+    if ((*it)->is_cgi_timeout()) {
+      Log::cinfo() << "CGI timeout: connfd(" << (*it)->get_fd() << ")"
+                   << " port("
+                   << (*it)->client_socket->socket->get_client_port() << ")"
+                   << std::endl;
+      (*it)->handle_cgi_timeout();
+    } else if ((*it)->is_timeout()) {
       Log::cinfo() << "Connection timeout: connfd(" << (*it)->get_fd() << ")"
                    << " port("
                    << (*it)->client_socket->socket->get_client_port() << ")"

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -219,7 +219,9 @@ int Server::wait() throw() {
   ready_rfds = this->readfds;
   ready_wfds = this->writefds;
   // timeout 1s
-  struct timeval timeout = {.tv_sec = 1, .tv_usec = 0};
+  struct timeval timeout;
+  timeout.tv_sec = 1;
+  timeout.tv_usec = 0;
   int result = ::select(maxfd + 1, &ready_rfds, &ready_wfds, NULL, &timeout);
   if (result < 0) {
     Log::cerror() << "select error: " << strerror(errno) << std::endl;

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -49,9 +49,10 @@ class Server {
                   struct addrinfo** result);  // throwable
   int listen(const config::Listen& l);        // throwable
 
-  void remove_connection(util::shared_ptr<Connection> connection) throw();
+  ConnIterator remove_connection(
+      util::shared_ptr<Connection> connection) throw();
 
-  void remove_all_connections() throw();
+  void remove_timeout_connections() throw();
 
   void accept(util::shared_ptr<Socket> sock) throw();
 

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -25,6 +25,7 @@ class Server {
   fd_set readfds, writefds;
   fd_set ready_rfds, ready_wfds;
   int maxfd;
+  time_t last_timeout_check;
 
  private:
   Server() throw();  // Do not implement

--- a/srcs/Socket.cpp
+++ b/srcs/Socket.cpp
@@ -1,0 +1,46 @@
+#include "Socket.hpp"
+
+static int get_port(struct sockaddr_storage& addr) throw() {
+  if (addr.ss_family == AF_INET6) {
+    return ntohs(((struct sockaddr_in6*)&addr)->sin6_port);
+  } else if (addr.ss_family == AF_INET) {
+    return ntohs(((struct sockaddr_in*)&addr)->sin_port);
+  } else {
+    Log::error("Invalid socket family");
+    return -1;
+  }
+}
+
+int Socket::get_server_port() throw() { return get_port(saddr); }
+
+int Socket::get_client_port() throw() { return get_port(caddr); }
+
+util::shared_ptr<Socket> Socket::accept() {  // throwable
+  struct sockaddr_storage caddr;
+  socklen_t caddrlen = sizeof(caddr);
+  int connfd = ::accept(fd, (struct sockaddr*)&caddr, &caddrlen);
+  static unsigned int cnt = 0;
+  cnt++;
+  Log::cinfo() << cnt << "th connection accepted: "
+               << "connfd(" << connfd << "), port(" << get_port(caddr) << ")"
+               << std::endl;
+  if (connfd < 0) {
+    Log::error("accept() failed");
+    throw std::runtime_error("accept() failed");
+  }
+  // If allocation failed, must close connfd
+  util::shared_ptr<Socket> connsock;
+  try {
+    connsock = util::shared_ptr<Socket>(
+        new Socket(connfd, (struct sockaddr*)&saddr, (struct sockaddr*)&caddr,
+                   saddrlen, caddrlen));
+    // connsock->set_nolinger(0);
+    return connsock;
+  } catch (std::exception& e) {
+    Log::error("new Socket() failed");
+    if (::close(connfd) < 0) {
+      Log::error("close() failed");
+    }
+    throw e;
+  }
+}

--- a/srcs/StreamCleaner.hpp
+++ b/srcs/StreamCleaner.hpp
@@ -1,0 +1,28 @@
+#ifndef STREAMCLEANER_HPP
+#define STREAMCLEANER_HPP
+
+#include <sstream>
+
+class StreamCleaner {
+ private:
+  std::stringstream &rss, &wss;
+
+ public:
+  StreamCleaner(std::stringstream& rss, std::stringstream& wss)
+      : rss(rss), wss(wss) {}
+  ~StreamCleaner() {
+    if (rss.bad() || wss.bad()) return;
+    if (rss.eof()) {
+      Log::debug("rss.eof(), so clear rss");
+      rss.str("");
+    }
+    if (wss.eof()) {
+      Log::debug("wss.eof(), so clear wss");
+      wss.str("");
+    }
+    rss.clear();
+    wss.clear();
+  }
+};
+
+#endif

--- a/srcs/http_special_response.hpp
+++ b/srcs/http_special_response.hpp
@@ -33,4 +33,8 @@ static const char http_error_500_page[] =
     "<body>" CRLF
     "<center><h1>500 Internal Server Error</h1></center>" CRLF ERROR_TAIL;
 
+static const char http_error_504_page[] =
+    "<html>" CRLF "<head><title>504 Gateway Timeout</title></head>" CRLF
+    "<body>" CRLF
+    "<center><h1>504 Gateway Timeout</h1></center>" CRLF ERROR_TAIL;
 #endif

--- a/tests/html/cgi/infinite_loop.py
+++ b/tests/html/cgi/infinite_loop.py
@@ -1,0 +1,6 @@
+import time
+
+if __name__ == '__main__':
+    while True:
+        print('Hello, world!')
+        time.sleep(1)

--- a/tests/requests/37
+++ b/tests/requests/37
@@ -1,0 +1,3 @@
+GET /cgi/infinite_loop.py HTTP/1.1
+Host: webserv
+

--- a/tests/requests/38
+++ b/tests/requests/38
@@ -1,0 +1,4 @@
+GET /cgi-invalid-handler/echo.py HTTP/1.1
+Content-Length: 27
+
+Can you echo this response?

--- a/tests/responses/27
+++ b/tests/responses/27
@@ -1,3 +1,4 @@
 HTTP/1.1 301 Moved Permanently
 Location: https://www.google.com
+Content-Length: 0
 

--- a/tests/responses/28
+++ b/tests/responses/28
@@ -1,3 +1,4 @@
 HTTP/1.1 301 Moved Permanently
 Location: /kapouet/pouic/toto/pouet
+Content-Length: 0
 

--- a/tests/responses/37
+++ b/tests/responses/37
@@ -1,0 +1,11 @@
+HTTP/1.1 504 Gateway Timeout
+Content-Type: text/html
+Content-Length: 166
+
+<html>
+<head><title>504 Gateway Timeout</title></head>
+<body>
+<center><h1>504 Gateway Timeout</h1></center>
+<hr><center>webserv/0.0.1</center>
+</body>
+</html>

--- a/tests/responses/38
+++ b/tests/responses/38
@@ -1,0 +1,11 @@
+HTTP/1.1 500 Internal Server Error
+Content-Type: text/html
+Content-Length: 178
+
+<html>
+<head><title>500 Internal Server Error</title></head>
+<body>
+<center><h1>500 Internal Server Error</h1></center>
+<hr><center>webserv/0.0.1</center>
+</body>
+</html>

--- a/tests/test.conf
+++ b/tests/test.conf
@@ -95,5 +95,11 @@ http {
 			cgi_handler .py /usr/bin/python3; # server/location
 			cgi_handler .pl /usr/bin/perl;
 		}
+
+		location /cgi-invalid-handler/ {
+			alias ./tests/html/cgi/;
+			limit_except GET POST;
+			cgi_handler .py /usr/bin/python4;
+		}
 	}
 }

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -26,7 +26,7 @@ mkdir -p /tmp/www/pouic/toto \
 # 2. Tests
 # arg for save error count
 cnt=0
-for i in {1..37}; do
+for i in {1..38}; do
   echo -n "Test${i}   : " | tee -a error.log
   # skip test 12, 23, 29
   if [ $i -eq 12 ] || [ $i -eq 23 ] || [ $i -eq 29 ]; then

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -26,7 +26,7 @@ mkdir -p /tmp/www/pouic/toto \
 # 2. Tests
 # arg for save error count
 cnt=0
-for i in {1..36}; do
+for i in {1..37}; do
   echo -n "Test${i}   : " | tee -a error.log
   # skip test 12, 23, 29
   if [ $i -eq 12 ] || [ $i -eq 23 ] || [ $i -eq 29 ]; then

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -68,6 +68,16 @@ function python_test() {
 
 python_test
 
+# 2.5. Check if there are zombie cgi processes
+echo -n "Zombie CGI : "
+ps aux | grep "cgi-bin" | grep -v grep >out
+if ps | grep defunct | grep -qv grep; then
+	print_ng
+	let cnt++
+else
+	print_ok
+fi
+
 # 3. Clean up
 rm -f out *.tmp error.log-e
 pkill webserv


### PR DESCRIPTION
- Clientとの通信のタイムアウト
- CGIプロセスとの通信のタイムアウト
の二つを実装しました。

~~尚、あるコネクションから応答がなくても、他のコネクションと常に通信がされているような場合だとタイムアウトにならないので、この場合の考慮も本当は必要かも。~~

~~現状の実装だと、タイムアウト確認するのが~~

~~- そのコネクションのI/Oをするタイミング~~
~~- selectがタイムアウトしたタイミング~~

~~の二つしかないため。本当は他のコネクションとI/Oしたタイミングでも1秒に一回くらいはタイムアウト確認をすべきか。~~

[e9fe450](https://github.com/usatie/webserv/pull/62/commits/e9fe4505323081787ac143575151c637f7514a39) にて数秒に一回タイムアウト確認を必ず入れるようにしたので、解決